### PR TITLE
Fixed several things

### DIFF
--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinBlockBreakingKineticTileEntity.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinBlockBreakingKineticTileEntity.java
@@ -25,8 +25,7 @@ public abstract class MixinBlockBreakingKineticTileEntity {
         at = @At(
             value = "INVOKE",
             target = "Lcom/simibubi/create/content/contraptions/components/actors/BlockBreakingKineticTileEntity;getBreakingPos()Lnet/minecraft/core/BlockPos;"
-        ),
-        remap = false
+        )
     )
     private BlockPos getBreakingBlockPos(final BlockBreakingKineticTileEntity self) {
         final BlockPos orig = this.getBreakingPos();

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinSuperGlueRemovalPacket.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinSuperGlueRemovalPacket.java
@@ -1,0 +1,31 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create;
+
+import com.simibubi.create.content.contraptions.components.structureMovement.glue.SuperGlueRemovalPacket;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.phys.Vec3;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+
+@Mixin(SuperGlueRemovalPacket.class)
+public abstract class MixinSuperGlueRemovalPacket {
+    @Redirect(method = "lambda$handle$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;distanceToSqr(Lnet/minecraft/world/phys/Vec3;)D"))
+    private double redirectPlayerDistanceToSqr(final ServerPlayer instance, final Vec3 vec3) {
+        Vec3 newVec3 = vec3;
+        if (VSGameUtilsKt.isBlockInShipyard(instance.level, new BlockPos(vec3.x, vec3.y, vec3.z))) {
+            final Ship ship = VSGameUtilsKt.getShipManagingPos(instance.level, vec3);
+            if (ship != null) {
+                newVec3 = VectorConversionsMCKt.toMinecraft(ship.getShipToWorld().transformPosition(new Vector3d(vec3.x, vec3.y, vec3.z)));
+            }
+        }
+        return instance.distanceToSqr(newVec3);
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinTrainRelocationPacket.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinTrainRelocationPacket.java
@@ -1,0 +1,44 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create;
+
+import com.simibubi.create.content.contraptions.components.structureMovement.interaction.controls.ControlsInputPacket;
+import com.simibubi.create.content.logistics.trains.entity.Train;
+import com.simibubi.create.content.logistics.trains.entity.TrainRelocationPacket;
+import com.simibubi.create.foundation.networking.SimplePacketBase;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+import java.util.UUID;
+
+@Mixin(TrainRelocationPacket.class)
+public abstract class MixinTrainRelocationPacket {
+    @Unique
+    private Level world;
+
+    @Redirect(method = "lambda$handle$2", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;closerThan(Lnet/minecraft/core/Position;D)Z"))
+    private boolean redirectCloserThan(final Vec3 instance, final Position arg, final double d) {
+        Vec3 newVec3 = (Vec3) arg;
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(this.world, arg);
+        if (ship != null) {
+            newVec3 = VSGameUtilsKt.toWorldCoordinates(ship, (Vec3) arg);
+        }
+        return instance.closerThan(newVec3, d);
+    }
+
+    @Inject(method = "lambda$handle$2", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntity(I)Lnet/minecraft/world/entity/Entity;"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void injectCaptureLevel(SimplePacketBase.Context ctx, CallbackInfo ci, ServerPlayer sender, Train train) {
+        this.world = sender.level;
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinContraptionHandlerClient.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinContraptionHandlerClient.java
@@ -2,11 +2,21 @@ package org.valkyrienskies.clockwork.fabric.mixin.create.client;
 
 import com.simibubi.create.content.contraptions.components.structureMovement.ContraptionHandlerClient;
 import com.simibubi.create.foundation.utility.Couple;
+
+import java.util.Iterator;
 import java.util.List;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4d;
+import org.joml.Matrix4f;
+import org.joml.Quaterniond;
 import org.joml.Vector3d;
+import org.joml.primitives.AABBd;
+import org.joml.primitives.AABBic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -19,31 +29,33 @@ import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 @Mixin(ContraptionHandlerClient.class)
 public abstract class MixinContraptionHandlerClient {
 
-    @Inject(
-        method = "getRayInputs",
-        at = @At(
-            value = "INVOKE",
-            target = "Lcom/simibubi/create/foundation/utility/Couple;create(Ljava/lang/Object;Ljava/lang/Object;)Lcom/simibubi/create/foundation/utility/Couple;"
-        ), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true
-    )
-    private static void redirectedOrigin(
-        final LocalPlayer player, final CallbackInfoReturnable<Couple<Vec3>> cir, final Minecraft mc,
-        Vec3 origin, final double reach, Vec3 target) {
-        final Ship ship = VSGameUtilsKt.getShipManagingPos(player.level, player.getOnPos());
+    @Inject(method = "getRayInputs", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/foundation/utility/Couple;create(Ljava/lang/Object;Ljava/lang/Object;)Lcom/simibubi/create/foundation/utility/Couple;"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+    private static void redirectedOrigin(final LocalPlayer player, final CallbackInfoReturnable<Couple<Vec3>> cir, final Minecraft mc, Vec3 origin, final double reach, Vec3 target) {
 
-        if (ship != null) {
-            final List<Vector3d>
-                originShips =
-                VSGameUtilsKt.transformToNearbyShipsAndWorld(player.level, origin.x, origin.y, origin.z, 10);
-            if (!originShips.isEmpty()) {
-                origin = VectorConversionsMCKt.toMinecraft(originShips.get(0));
-            }
+        if (mc.hitResult != null) {
+            //Vec3 searchLocation = mc.hitResult.getLocation();
+            AABB searchAABB = new AABB(origin, target).inflate(0.25, 2, 0.25);
+            final Iterator<Ship> ships = VSGameUtilsKt.getShipsIntersecting(player.level, searchAABB).iterator();
 
-            final List<Vector3d>
-                targetShips =
-                VSGameUtilsKt.transformToNearbyShipsAndWorld(player.level, target.x, target.y, target.z, 10);
-            if (!targetShips.isEmpty()) {
-                target = VectorConversionsMCKt.toMinecraft(targetShips.get(0));
+            if (ships.hasNext()) {
+                Ship ship = ships.next();
+
+                Matrix4d world2Ship = (Matrix4d) ship.getTransform().getWorldToShip();
+                AABBic shAABBi = ship.getShipAABB();
+                AABB shipAABB = new AABB(shAABBi.minX(), shAABBi.minY(), shAABBi.minZ(), shAABBi.maxX(), shAABBi.maxY(), shAABBi.maxZ());
+
+
+                origin = VectorConversionsMCKt.toMinecraft(world2Ship.transformPosition(VectorConversionsMCKt.toJOML(origin)));
+                target = VectorConversionsMCKt.toMinecraft(world2Ship.transformPosition(VectorConversionsMCKt.toJOML(target)));
+
+                Quaterniond tempQuat = new Quaterniond();
+                if (player.getVehicle() != null && player.getVehicle().getBoundingBox().intersects(shipAABB.inflate(20))) {
+                    ship.getTransform().getWorldToShip().getNormalizedRotation(tempQuat);
+                    tempQuat.invert();
+                    Vector3d offset = VectorConversionsMCKt.toJOML(target.subtract(origin));
+                    tempQuat.transform(offset);
+                    target = origin.add(VectorConversionsMCKt.toMinecraft(offset));
+                }
             }
         }
         cir.setReturnValue(Couple.create(origin, target));

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinOrientedContraptionEntity.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinOrientedContraptionEntity.java
@@ -1,0 +1,68 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create.client;
+
+import com.jozufozu.flywheel.util.transform.TransformStack;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.simibubi.create.content.contraptions.components.structureMovement.AbstractContraptionEntity;
+import com.simibubi.create.content.contraptions.components.structureMovement.OrientedContraptionEntity;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4d;
+import org.joml.Quaterniond;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.valkyrienskies.core.api.ships.ClientShip;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+
+@Mixin(OrientedContraptionEntity.class)
+public class MixinOrientedContraptionEntity {
+
+    @Shadow
+    private Vec3 getCartOffset(float partialTicks, Entity ridingEntity) {
+        return Vec3.ZERO;
+    }
+
+    @Redirect(method = "applyLocalTransforms", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/contraptions/components/structureMovement/OrientedContraptionEntity;repositionOnCart(Lcom/mojang/blaze3d/vertex/PoseStack;FLnet/minecraft/world/entity/Entity;)V"))
+    private void redirectRepositionOnCart(OrientedContraptionEntity instance, PoseStack matrixStack, float partialTicks, Entity ridingEntity) {
+
+        Vec3 cartPos = getCartOffset(partialTicks, ridingEntity);
+        if (cartPos != Vec3.ZERO) matrixStack.translate(cartPos.x, cartPos.y, cartPos.z);
+
+        ClientShip ship = (ClientShip) VSGameUtilsKt.getShipManagingPos(instance.getCommandSenderWorld(), ridingEntity.blockPosition());
+        if (ship != null) {
+            Quaterniond quaternion = new Quaterniond();
+            ship.getRenderTransform().getShipToWorld().getNormalizedRotation(quaternion);
+            TransformStack.cast(matrixStack).rotateCentered(VectorConversionsMCKt.toMinecraft(quaternion));
+        }
+    }
+
+    @Redirect(method = "repositionOnContraption", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(DDD)V", ordinal = 0))
+    private void redirectTranslate(final PoseStack instance, final double pose, final double d, final double e) {
+        instance.translate(pose, d, e);
+
+        ClientShip ship = (ClientShip) VSGameUtilsKt.getShipManagingPos(Minecraft.getInstance().level, ((AbstractContraptionEntity) (Object) this).getVehicle().blockPosition());
+        if (ship != null) {
+            Quaterniond quaternion = new Quaterniond();
+            ship.getRenderTransform().getShipToWorld().getNormalizedRotation(quaternion);
+            TransformStack.cast(instance).rotateCentered(VectorConversionsMCKt.toMinecraft(quaternion));
+        }
+    }
+
+    @Redirect(method = "getContraptionOffset", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity;getPassengerPosition(Lnet/minecraft/world/entity/Entity;F)Lnet/minecraft/world/phys/Vec3;"))
+    private Vec3 redirectGetPassengerPosition(AbstractContraptionEntity instance, Entity passenger, float partialTicks) {
+        Vec3 result = instance.getPassengerPosition(passenger, partialTicks);
+
+        ClientShip ship = (ClientShip) VSGameUtilsKt.getShipManagingPos(instance.getCommandSenderWorld(), instance.position());
+        if (ship != null) {
+            Vector3d dest = new Vector3d();
+            ship.getRenderTransform().getShipToWorld().transformPosition(VectorConversionsMCKt.toJOML(result), dest);
+            result = VectorConversionsMCKt.toMinecraft(dest);
+        }
+        return result;
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinTrainRelocator.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinTrainRelocator.java
@@ -1,0 +1,36 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create.client;
+
+import com.simibubi.create.content.logistics.trains.entity.Train;
+import com.simibubi.create.content.logistics.trains.entity.TrainRelocationPacket;
+import com.simibubi.create.content.logistics.trains.entity.TrainRelocator;
+import com.simibubi.create.foundation.networking.SimplePacketBase;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(TrainRelocator.class)
+public abstract class MixinTrainRelocator {
+
+    @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;closerThan(Lnet/minecraft/core/Position;D)Z"))
+    private static boolean redirectCloserThan(final Vec3 instance, final Position arg, final double d) {
+        Vec3 newVec3 = (Vec3) arg;
+        Level world = Minecraft.getInstance().player.level;
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(world, arg);
+        if (ship != null) {
+            newVec3 = VSGameUtilsKt.toWorldCoordinates(ship, (Vec3) arg);
+        }
+        return instance.closerThan(newVec3, d);
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/flywheel/client/MixinTileInstanceManager.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/flywheel/client/MixinTileInstanceManager.java
@@ -24,7 +24,7 @@ import org.valkyrienskies.core.api.ships.ClientShip;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.fabric.mixinducks.MixinTileInstanceManagerDuck;
 
-@Mixin(value = BlockEntityInstanceManager.class, remap = false)
+@Mixin(value = BlockEntityInstanceManager.class)
 @ParametersAreNonnullByDefault
 public abstract class MixinTileInstanceManager extends InstanceManager<BlockEntity> implements
     MixinTileInstanceManagerDuck {

--- a/fabric/src/main/resources/vs_clockwork.mixins.json
+++ b/fabric/src/main/resources/vs_clockwork.mixins.json
@@ -13,9 +13,12 @@
     "create.MixinFriendlyByteBuf",
     "create.MixinTileEntityConfigurationPacket",
     "create.MixinTrackNodeLocation",
-    "create.MixinContraptionCollider"
+    "create.MixinContraptionCollider",
+    "create.MixinSuperGlueRemovalPacket",
+    "create.MixinTrainRelocationPacket"
   ],
   "client": [
+    "create.client.MixinTrainRelocator",
     "create.client.MixinOrientedContraptionEntity",
     "create.client.MixinCarriageContraptionInstance",
     "create.client.MixinContraptionHandlerClient",

--- a/fabric/src/main/resources/vs_clockwork.mixins.json
+++ b/fabric/src/main/resources/vs_clockwork.mixins.json
@@ -16,6 +16,7 @@
     "create.MixinContraptionCollider"
   ],
   "client": [
+    "create.client.MixinOrientedContraptionEntity",
     "create.client.MixinCarriageContraptionInstance",
     "create.client.MixinContraptionHandlerClient",
     "create.client.MixinContraptionRenderDispatcher",


### PR DESCRIPTION
Fixed Minecart Contraption and contraption on contraption not rotating with ship
Fixed train relocation on ships and improved the method for raytracing for contraption interaction
Removed remaps from 2 OG forge-based mixins causing crashes on load outside of the devenv


Minecart Contraptions don't have any collisions on ships, Not sure if related to minecarts not showing up on ships, work for the future