### PR TITLE
Fixed SoundScapes, Crushing wheels and Fans Air currents

### DIFF
--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinAirCurrent.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinAirCurrent.java
@@ -1,0 +1,119 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create;
+
+import com.simibubi.create.content.contraptions.components.fan.AirCurrent;
+import com.simibubi.create.content.contraptions.components.fan.IAirCurrentSource;
+import com.simibubi.create.foundation.utility.VecHelper;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.joml.Vector3d;
+import org.joml.primitives.AABBd;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+import org.valkyrienskies.mod.common.world.RaycastUtilsKt;
+import java.util.Iterator;
+import java.util.List;
+
+@Mixin(AirCurrent.class)
+public abstract class MixinAirCurrent {
+
+    @Redirect(method = "getFlowLimit", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;clipWithInteractionOverride(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/phys/BlockHitResult;"))
+    private static BlockHitResult redirectClip(Level instance, Vec3 vec3, Vec3 vec32, BlockPos blockPos, VoxelShape voxelShape, BlockState blockState) {
+        return RaycastUtilsKt.clipIncludeShips(instance, new ClipContext(vec3, vec32, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, null));
+    }
+
+    @Redirect(method = "findEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;"))
+    private List<Entity> redirectFindEntities(Level instance, Entity entity, AABB aabb) {
+        return instance.getEntities(entity, VSGameUtilsKt.transformAabbToWorld(instance, aabb));
+    }
+
+    @Redirect(method = "tickAffectedEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/AABB;intersects(Lnet/minecraft/world/phys/AABB;)Z"))
+    private boolean redirectIntersects(AABB instance, AABB other) {
+        Level level = this.source.getAirCurrentWorld();
+        if (level != null) {
+            Iterator<Ship> ships = VSGameUtilsKt.getShipsIntersecting(level, instance).iterator();
+            if (ships.hasNext()) {
+                AABBd result = new AABBd();
+                VectorConversionsMCKt.toJOML(instance).transform(ships.next().getTransform().getWorldToShip(), result);
+                instance = VectorConversionsMCKt.toMinecraft(result);
+            }
+        }
+        return instance.intersects(other);
+    }
+
+    @Inject(
+            method = "tickAffectedEntities",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/Entity;getDeltaMovement()Lnet/minecraft/world/phys/Vec3;"
+            ),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void harvester(Level world, Direction facing, CallbackInfo ci, Iterator<Entity> iterator, Entity entity, Vec3 center, Vec3i flow, float sneakModifier, float speed, double entityDistance, float acceleration) {
+        ship = VSGameUtilsKt.getShipManagingPos(world, source.getAirCurrentPos());
+        if (ship != null) {
+            Vector3d tempVec = new Vector3d();
+            ship.getTransform().getShipToWorld().transformDirection(flow.getX(), flow.getY(), flow.getZ(), tempVec);
+            transformedFlow = VectorConversionsMCKt.toMinecraft(tempVec);
+        }
+        this.acceleration = acceleration;
+    }
+
+    @Redirect(method = "tickAffectedEntities",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V")
+    )
+    private void redirectSetDeltaMovement(Entity instance, Vec3 motion) {
+        if (ship != null) {
+            Vec3 previousMotion = instance.getDeltaMovement();
+            double xIn = Mth.clamp(transformedFlow.x * acceleration - previousMotion.x, -maxAcceleration, maxAcceleration);
+            double yIn = Mth.clamp(transformedFlow.y * acceleration - previousMotion.y, -maxAcceleration, maxAcceleration);
+            double zIn = Mth.clamp(transformedFlow.z * acceleration - previousMotion.z, -maxAcceleration, maxAcceleration);
+            instance.setDeltaMovement(previousMotion.add(new Vec3(xIn, yIn, zIn).scale(1 / 8f)));
+        } else {
+            instance.setDeltaMovement(motion);
+        }
+    }
+
+    @Redirect(method = "tickAffectedEntities", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/foundation/utility/VecHelper;getCenterOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"), allow = 1)
+    private Vec3 redirectGetCenterOf(Vec3i pos) {
+        Vec3 result = VecHelper.getCenterOf(pos);
+        if (this.source.getAirCurrentWorld() != null) {
+            Ship ship = VSGameUtilsKt.getShipManagingPos(this.source.getAirCurrentWorld(), result);
+            if (ship != null) {
+                Vector3d tempVec = new Vector3d();
+                ship.getTransform().getShipToWorld().transformPosition(result.x, result.y, result.z, tempVec);
+                result = VectorConversionsMCKt.toMinecraft(tempVec);
+            }
+        }
+        return result;
+    }
+
+    @Unique
+    private Vec3 transformedFlow = Vec3.ZERO;
+    @Unique
+    private float acceleration;
+    @Unique
+    private final float maxAcceleration = 5;
+    @Unique
+    private Ship ship;
+    @Shadow
+    @Final
+    public IAirCurrentSource source;
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinAirFlowParticle.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinAirFlowParticle.java
@@ -1,0 +1,65 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create;
+
+import com.simibubi.create.content.contraptions.components.fan.AirCurrent;
+import com.simibubi.create.content.contraptions.components.fan.IAirCurrentSource;
+import com.simibubi.create.content.contraptions.particle.AirFlowParticle;
+import com.simibubi.create.foundation.utility.VecHelper;
+import net.minecraft.core.Vec3i;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Vector3d;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+
+@Mixin(AirFlowParticle.class)
+public abstract class MixinAirFlowParticle {
+
+    @Shadow
+    @Final
+    private IAirCurrentSource source;
+
+    @Redirect(method = "tick", at = @At(value = "FIELD", target = "Lcom/simibubi/create/content/contraptions/components/fan/AirCurrent;bounds:Lnet/minecraft/world/phys/AABB;", opcode = Opcodes.GETFIELD))
+    private AABB redirectBounds(AirCurrent instance) {
+        Level level = instance.source.getAirCurrentWorld();
+        if (level != null) {
+            return VSGameUtilsKt.transformAabbToWorld(level, instance.bounds);
+        }
+        return instance.bounds;
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/foundation/utility/VecHelper;getCenterOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"), allow = 1)
+    private Vec3 redirectGetCenterOf(Vec3i pos) {
+        Vec3 result = VecHelper.getCenterOf(pos);
+        if (this.source.getAirCurrentWorld() != null) {
+            Ship ship = VSGameUtilsKt.getShipManagingPos(this.source.getAirCurrentWorld(), result);
+            if (ship != null) {
+                Vector3d tempVec = new Vector3d();
+                ship.getTransform().getShipToWorld().transformPosition(result.x, result.y, result.z, tempVec);
+                result = VectorConversionsMCKt.toMinecraft(tempVec);
+            }
+        }
+        return result;
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;atLowerCornerOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"), allow = 1)
+    private Vec3 redirectToLowerCorner(Vec3i pos) {
+        Vec3 result = Vec3.atLowerCornerOf(pos);
+        if (this.source.getAirCurrentWorld() != null) {
+            Ship ship = VSGameUtilsKt.getShipManagingPos(this.source.getAirCurrentWorld(), this.source.getAirCurrentPos());
+            if (ship != null) {
+                Vector3d tempVec = new Vector3d();
+                ship.getTransform().getShipToWorld().transformDirection(result.x, result.y, result.z, tempVec);
+                result = VectorConversionsMCKt.toMinecraft(tempVec);
+            }
+        }
+        return result;
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinCrushingWheelControllerTileEntity.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/MixinCrushingWheelControllerTileEntity.java
@@ -1,0 +1,114 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create;
+
+import com.simibubi.create.content.contraptions.components.crusher.CrushingWheelControllerBlock;
+import com.simibubi.create.content.contraptions.components.crusher.CrushingWheelControllerTileEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Vector3d;
+import org.joml.primitives.AABBd;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+@Mixin(CrushingWheelControllerTileEntity.class)
+public abstract class MixinCrushingWheelControllerTileEntity {
+
+    @Shadow
+    public float crushingspeed;
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"))
+    private List<Entity> redirectBounds(Level instance, Entity entity, AABB area, Predicate<Entity> predicate) {
+        if (instance != null) {
+            area = VSGameUtilsKt.transformAabbToWorld(instance, area);
+            return instance.getEntities(entity, area, predicate);
+        }
+        return new ArrayList<Entity>();
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/AABB;intersects(Lnet/minecraft/world/phys/AABB;)Z"))
+    private boolean redirectIntersects(AABB instance, AABB other) {
+        Level level = ((CrushingWheelControllerTileEntity) (Object) this).getLevel();
+        if (level != null) {
+            Iterator<Ship> ships = VSGameUtilsKt.getShipsIntersecting(level, instance).iterator();
+            if (ships.hasNext()) {
+                AABBd result = new AABBd();
+                VectorConversionsMCKt.toJOML(instance).transform(ships.next().getTransform().getWorldToShip(), result);
+                instance = VectorConversionsMCKt.toMinecraft(result);
+            }
+        }
+        return instance.intersects(other);
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"))
+    private void redirectSetDeltaMovement(Entity instance, Vec3 motion) {
+
+        BlockPos worldPosition = ((CrushingWheelControllerTileEntity) (Object) this).getBlockPos();
+        Direction facing = ((CrushingWheelControllerTileEntity) (Object) this)
+                .getBlockState().getValue(CrushingWheelControllerBlock.FACING);
+        Vec3 transformedPos = getTransformedPosition(instance);
+        double xMotion = ((worldPosition.getX() + .5) - transformedPos.x) / 2;
+        double zMotion = ((worldPosition.getZ() + .5) - transformedPos.z) / 2;
+
+        if (instance.isShiftKeyDown())
+            xMotion = zMotion = 0;
+        double movement = Math.max(-(this.crushingspeed * 4) / 4f, -.5f) * -facing.getAxisDirection().getStep();
+
+        Vec3 transformedDirection = directionShip2World(instance,
+                new Vec3(
+                        facing.getAxis() == Direction.Axis.X ? movement : xMotion,
+                        facing.getAxis() == Direction.Axis.Y ? movement : 0f,
+                        facing.getAxis() == Direction.Axis.Z ? movement : zMotion
+                ));
+
+        instance.setDeltaMovement(transformedDirection);
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;getX()D"))
+    private double redirectEntityGetX(Entity instance) {
+        return getTransformedPosition(instance).x;
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;getY()D"))
+    private double redirectEntityGetY(Entity instance) {
+        return getTransformedPosition(instance).y;
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;getZ()D"))
+    private double redirectEntityGetZ(Entity instance) {
+        return getTransformedPosition(instance).z;
+    }
+
+    private Vec3 getTransformedPosition(Entity instance) {
+        Vec3 result = instance.position();
+        Ship ship = VSGameUtilsKt.getShipManagingPos(instance.level, ((CrushingWheelControllerTileEntity) (Object) this).getBlockPos());
+        if (ship != null) {
+            Vector3d tempVec = new Vector3d();
+            ship.getTransform().getWorldToShip().transformPosition(result.x, result.y, result.z, tempVec);
+            result = VectorConversionsMCKt.toMinecraft(tempVec);
+        }
+        return result;
+    }
+
+    private Vec3 directionShip2World(Entity instance, Vec3 direction) {
+        Vec3 result = direction;
+        Ship ship = VSGameUtilsKt.getShipManagingPos(instance.level, ((CrushingWheelControllerTileEntity) (Object) this).getBlockPos());
+        if (ship != null) {
+            Vector3d tempVec = new Vector3d();
+            ship.getTransform().getShipToWorld().transformDirection(result.x, result.y, result.z, tempVec);
+            result = VectorConversionsMCKt.toMinecraft(tempVec);
+        }
+        return result;
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinSoundScapes.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/mixin/create/client/MixinSoundScapes.java
@@ -1,0 +1,43 @@
+package org.valkyrienskies.clockwork.fabric.mixin.create.client;
+
+import com.simibubi.create.foundation.sound.SoundScapes;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(SoundScapes.class)
+public abstract class MixinSoundScapes {
+
+    @Redirect(method = "outOfRange", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;closerThan(Lnet/minecraft/core/Vec3i;D)Z"))
+    private static boolean redirectCloserThan(BlockPos instance, Vec3i vec3i, double v) {
+        Vec3 newVec3 = new Vec3(vec3i.getX(), vec3i.getY(), vec3i.getZ());
+        Level world = Minecraft.getInstance().player.level;
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(world, newVec3);
+        if (ship != null) {
+            newVec3 = VSGameUtilsKt.toWorldCoordinates(ship, newVec3);
+        }
+        return new Vec3(instance.getX(), instance.getY(), instance.getZ()).closerThan(newVec3, v);
+    }
+
+    @ModifyVariable(method = "play", at = @At("HEAD"), index = 1, argsOnly = true)
+    private static BlockPos modBlockPos(BlockPos value) {
+        BlockPos result = value;
+        Level world = Minecraft.getInstance().player.level;
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(world, value);
+        if (ship != null) {
+            Vector3d tempVec = new Vector3d();
+            ship.getTransform().getShipToWorld().transformPosition(value.getX(), value.getY(), value.getZ(), tempVec);
+            result = new BlockPos(tempVec.x, tempVec.y, tempVec.z);
+        }
+        return result;
+    }
+}

--- a/fabric/src/main/resources/vs_clockwork.mixins.json
+++ b/fabric/src/main/resources/vs_clockwork.mixins.json
@@ -20,9 +20,13 @@
     "create.MixinBeltMovementHandler",
     "create.MixinAbstractContraptionEntity",
     "create.MixinSeatEntity",
-    "create.MixinFilteringHandler"
+    "create.MixinFilteringHandler",
+    "create.MixinAirFlowParticle",
+    "create.MixinAirCurrent",
+    "create.MixinCrushingWheelControllerTileEntity"
   ],
   "client": [
+    "create.client.MixinSoundScapes",
     "create.client.MixinFilteringRenderer",
     "create.client.MixinTrainRelocator",
     "create.client.MixinOrientedContraptionEntity",

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ enabled_platforms=fabric,forge
 archives_base_name=clockwork
 maven_group=org.valkyrienskies
 # Dependencies
-vs2_version=2.1.0-beta8+387fda1589
+vs2_version=2.1.0-beta8+2672009640
 eureka_version=1.1.0-beta5+d1fdbd59fd
 minecraft_version=1.18.2
 architectury_version=4.10.86


### PR DESCRIPTION
Updated VS2 to latest to allow for bug fixes!
Soundscapes now play sounds in worldspace on ships so you can actually hear the sounds!
Crushing wheels will now actually take in and nom item entities instead of just flinging them away like a child that doesn't want its dinner
Fans suck (and blow)