### PR TITLE
[1.18.x] ComputerCraft Integration

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Kotlin
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.21"
     api "org.jetbrains.kotlin:kotlin-reflect:1.7.21"
+
+    // CC Restitched
+    modCompileOnly("curse.maven:cc-restitched-462672:3622561")
 }
 
 publishing {

--- a/common/src/main/java/org/valkyrienskies/clockwork/content/contraptions/sequenced_seat/SequencedSeatBlockEntity.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/content/contraptions/sequenced_seat/SequencedSeatBlockEntity.java
@@ -4,9 +4,11 @@ import com.simibubi.create.content.contraptions.relays.encased.SplitShaftTileEnt
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import org.valkyrienskies.clockwork.platform.PlatformUtils;
 import org.valkyrienskies.clockwork.util.MinecraftUtil;
 
 import java.util.Set;
@@ -115,6 +117,10 @@ public class SequencedSeatBlockEntity extends SplitShaftTileEntity {
     public void updateInput(Set<InputKey> pressedKeys) {
         if (this.pressedKeys.equals(pressedKeys))
             return;
+
+        if (!level.isClientSide)
+            if (PlatformUtils.isModLoaded("computercraft"))
+                PlatformUtils.sequencedSeatKeysUpdated((ServerLevel) this.level, this.worldPosition, pressedKeys);
 
         this.pressedKeys = pressedKeys;
         ticksSinceLastUpdate = 0;

--- a/common/src/main/java/org/valkyrienskies/clockwork/integration/cc/AfterblazerPeripheral.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/integration/cc/AfterblazerPeripheral.java
@@ -1,0 +1,64 @@
+package org.valkyrienskies.clockwork.integration.cc;
+
+import dan200.computercraft.api.lua.IArguments;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.lua.LuaValues;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.valkyrienskies.clockwork.content.contraptions.afterblazer.AfterblazerBlockEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AfterblazerPeripheral implements IPeripheral {
+    private final Level level;
+    private final BlockPos pos;
+    private final AfterblazerBlockEntity afterblazer;
+
+    public AfterblazerPeripheral(AfterblazerBlockEntity be) {
+        this.afterblazer = be;
+        this.level = be.getLevel();
+        this.pos = be.getBlockPos();
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "afterblazer";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral iPeripheral) {
+        return level != null && level.getBlockEntity(pos) instanceof AfterblazerBlockEntity;
+    }
+
+    @LuaFunction
+    public final void setGimbal(IArguments arg) throws LuaException {
+        Optional<Double> pitch = arg.optDouble(0);
+        if (pitch.isEmpty()) throw LuaValues.badArgumentOf(0, "number", pitch);
+        if (arg.count() == 1) this.afterblazer.setGimbal(pitch.get(), this.afterblazer.getGimbalYaw());
+
+        Optional<Double> yaw = arg.optDouble(1);
+        if (yaw.isEmpty()) throw LuaValues.badArgumentOf(1, "number", yaw);
+        this.afterblazer.setGimbal(pitch.get(), yaw.get());
+    }
+
+    @LuaFunction
+    public final double getGimbalPitch() {
+        return this.afterblazer.getGimbalPitch();
+    }
+
+    @LuaFunction
+    public final double getGimbalYaw() {
+        return this.afterblazer.getGimbalYaw();
+    }
+
+    @LuaFunction
+    public final Map<String, Double> getGimbal() {
+        return Map.of("pitch", this.afterblazer.getGimbalPitch(), "yaw", this.afterblazer.getGimbalYaw());
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/clockwork/platform/PlatformUtils.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/platform/PlatformUtils.java
@@ -3,9 +3,12 @@ package org.valkyrienskies.clockwork.platform;
 import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.behaviour.BehaviourType;
 import com.simibubi.create.foundation.tileEntity.behaviour.fluid.SmartFluidTankBehaviour;
+import dan200.computercraft.shared.computer.blocks.TileComputer;
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -16,7 +19,10 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import org.valkyrienskies.clockwork.content.contraptions.ballooner.BalloonerBlockEntity;
+import org.valkyrienskies.clockwork.content.contraptions.sequenced_seat.InputKey;
 import org.valkyrienskies.clockwork.util.fluid.CWFluidTankBehaviour;
+
+import java.util.Set;
 
 public class PlatformUtils {
 
@@ -59,4 +65,10 @@ public class PlatformUtils {
 
     @ExpectPlatform
     public static CWFluidTankBehaviour cwFluidTank(BehaviourType<CWFluidTankBehaviour> type, SmartTileEntity te, int tanks, long tankCapacity, boolean enforceVariety) {throw new AssertionError();}
+
+    @ExpectPlatform
+    public static boolean isModLoaded(String modId) {throw new AssertionError();}
+
+    @ExpectPlatform
+    public static void sequencedSeatKeysUpdated(ServerLevel level, BlockPos pos, Set<InputKey> keys) {throw new AssertionError();}
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -84,6 +84,9 @@ dependencies {
 //    modCompileOnly("me.shedaniel:RoughlyEnoughItems-api-fabric:${rei_version}")
 //    modCompileOnly("me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:${rei_version}")
 //    modCompileOnly("dev.emi:emi:${emi_version}")
+
+    // CC Restitched
+    modCompileOnly("curse.maven:cc-restitched-462672:3622561")
 }
 
 processResources {

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/ClockWorkModFabric.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/ClockWorkModFabric.java
@@ -8,6 +8,7 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import org.valkyrienskies.clockwork.*;
 import org.valkyrienskies.clockwork.content.events.ClockworkClientEvents;
@@ -17,6 +18,7 @@ import org.valkyrienskies.clockwork.fabric.config.AllClockworkConfigs;
 import org.valkyrienskies.clockwork.fabric.content.events.FabricClockworkClientEvents;
 import org.valkyrienskies.clockwork.fabric.content.events.FabricClockworkCommonEvents;
 import org.valkyrienskies.clockwork.fabric.content.events.FabricClockworkInputEvents;
+import org.valkyrienskies.clockwork.fabric.integration.cc_restiched.ClockworkFabricPeripheralProviders;
 import org.valkyrienskies.clockwork.platform.fabric.FallbackFabricTransfer;
 import org.valkyrienskies.mod.fabric.common.ValkyrienSkiesModFabric;
 
@@ -69,6 +71,9 @@ public class ClockWorkModFabric implements ModInitializer {
 
         ClockWorkMod.init();
         ClockWorkModFabric.init();
+
+        if (FabricLoader.getInstance().isModLoaded("computercraft"))
+            ClockworkFabricPeripheralProviders.register();
     }
 
     @Environment(EnvType.CLIENT)

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/integration/cc_restiched/CCEvents.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/integration/cc_restiched/CCEvents.java
@@ -1,0 +1,27 @@
+package org.valkyrienskies.clockwork.fabric.integration.cc_restiched;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.shared.computer.core.ServerComputer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import org.valkyrienskies.clockwork.content.contraptions.sequenced_seat.InputKey;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class CCEvents {
+    public static void sequencedSeatKeysUpdated(BlockPos pos, Set<InputKey> keys) {
+        List<String> stringKeys = new ArrayList<>(List.of());
+        for (InputKey key : keys) {
+            stringKeys.add(key.toString());
+        }
+
+        Set<BlockPos> possibleComputers = Set.of(pos.above(), pos.below(), pos.north(), pos.west(), pos.east(), pos.south());
+        for (ServerComputer computer : ComputerCraft.serverComputerRegistry.getComputers()) {
+            if (possibleComputers.contains(computer.getPosition()))
+                computer.queueEvent("command_seat_keys", stringKeys.toArray());
+        }
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/integration/cc_restiched/ClockworkFabricPeripheralProviders.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/fabric/integration/cc_restiched/ClockworkFabricPeripheralProviders.java
@@ -1,0 +1,28 @@
+package org.valkyrienskies.clockwork.fabric.integration.cc_restiched;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.valkyrienskies.clockwork.content.contraptions.afterblazer.AfterblazerBlockEntity;
+import org.valkyrienskies.clockwork.integration.cc.AfterblazerPeripheral;
+
+public class ClockworkFabricPeripheralProviders {
+    public static void register() {
+        ComputerCraftAPI.registerPeripheralProvider(new AfterblazerPeripheralProvider());
+    }
+
+    public static class AfterblazerPeripheralProvider implements IPeripheralProvider {
+        @NotNull
+        @Override
+        public IPeripheral getPeripheral(@NotNull Level level, @NotNull BlockPos blockPos, @NotNull Direction direction) {
+            if (level.getBlockEntity(blockPos) instanceof AfterblazerBlockEntity afterblazer) {
+                return new AfterblazerPeripheral(afterblazer);
+            }
+            return null;
+        }
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/clockwork/platform/fabric/PlatformUtilsImpl.java
+++ b/fabric/src/main/java/org/valkyrienskies/clockwork/platform/fabric/PlatformUtilsImpl.java
@@ -7,18 +7,15 @@ import com.simibubi.create.foundation.tileEntity.behaviour.BehaviourType;
 import com.simibubi.create.foundation.tileEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import io.github.fabricators_of_create.porting_lib.entity.ExtraSpawnDataEntity;
 import io.github.fabricators_of_create.porting_lib.mixin.common.accessor.ServerGamePacketListenerImplAccessor;
-import io.github.fabricators_of_create.porting_lib.transfer.TransferUtil;
-import io.github.fabricators_of_create.porting_lib.transfer.callbacks.TransactionCallback;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -26,15 +23,16 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
-import org.valkyrienskies.clockwork.content.contraptions.afterblazer.AfterblazerBlock;
 import org.valkyrienskies.clockwork.content.contraptions.afterblazer.AfterblazerBlockEntity.FuelType;
 import org.valkyrienskies.clockwork.content.contraptions.ballooner.BalloonerBlockEntity;
+import org.valkyrienskies.clockwork.content.contraptions.sequenced_seat.InputKey;
 import org.valkyrienskies.clockwork.fabric.FabricClockworkItems;
 import org.valkyrienskies.clockwork.fabric.config.AllClockworkConfigs;
-import org.valkyrienskies.clockwork.platform.SmartFluidTankBlockEntity;
+import org.valkyrienskies.clockwork.fabric.integration.cc_restiched.CCEvents;
 import org.valkyrienskies.clockwork.util.blocktype.EngineHeatLevel;
 import org.valkyrienskies.clockwork.util.fluid.CWFluidTankBehaviour;
+
+import java.util.Set;
 
 public class PlatformUtilsImpl {
     public static double getReachDistance(Player player) {
@@ -144,5 +142,13 @@ public class PlatformUtilsImpl {
 
     public static CWFluidTankBehaviour cwFluidTank(BehaviourType<CWFluidTankBehaviour> type, SmartTileEntity te, int tanks, long tankCapacity, boolean enforceVariety) {
         return new FabricCWFluidTankBehaviour(type, te, tanks, tankCapacity, enforceVariety);
+    }
+
+    public static boolean isModLoaded(String modId) {
+        return FabricLoader.getInstance().isModLoaded(modId);
+    }
+
+    public static void sequencedSeatKeysUpdated(ServerLevel level, BlockPos pos, Set<InputKey> keys) {
+        CCEvents.sequencedSeatKeysUpdated(pos, keys);
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -35,6 +35,8 @@ repositories {
                 includeGroup("com.simibubi.create")
             }
         }
+
+        maven { url = "https://cursemaven.com" }
     }
 
     flatDir { // REMOVE IF CBC HAS BEEN UPDATED
@@ -73,6 +75,9 @@ dependencies {
 
     // if you would like to add integration with JEI, uncomment this line.
 //    modCompileOnly("mezz.jei:jei-${minecraft_version}:${jei_forge_version}:api")
+
+    // CC Tweaked
+    modCompileOnly("curse.maven:cctweaked-282001:4061947")
 }
 
 processResources {

--- a/forge/src/main/java/org/valkyrienskies/clockwork/forge/ClockWorkModForge.java
+++ b/forge/src/main/java/org/valkyrienskies/clockwork/forge/ClockWorkModForge.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.loading.FMLLoader;
 import org.valkyrienskies.clockwork.*;
 import org.valkyrienskies.clockwork.data.ClockWorkTags;
 import org.valkyrienskies.clockwork.forge.config.AllClockworkConfigs;
-import org.valkyrienskies.clockwork.forge.integration.cc_restiched.ClockworkForgePeripheralProviders;
+import org.valkyrienskies.clockwork.forge.integration.cc_tweaked.ClockworkForgePeripheralProviders;
 
 import static org.valkyrienskies.clockwork.ClockWorkMod.REGISTRATE;
 

--- a/forge/src/main/java/org/valkyrienskies/clockwork/forge/ClockWorkModForge.java
+++ b/forge/src/main/java/org/valkyrienskies/clockwork/forge/ClockWorkModForge.java
@@ -12,9 +12,11 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLLoader;
 import org.valkyrienskies.clockwork.*;
 import org.valkyrienskies.clockwork.data.ClockWorkTags;
 import org.valkyrienskies.clockwork.forge.config.AllClockworkConfigs;
+import org.valkyrienskies.clockwork.forge.integration.cc_restiched.ClockworkForgePeripheralProviders;
 
 import static org.valkyrienskies.clockwork.ClockWorkMod.REGISTRATE;
 
@@ -79,6 +81,9 @@ public class ClockWorkModForge {
 
             ShaderLoader.init(modEventBus);
         });
+
+        if (FMLLoader.getLoadingModList().getModFileById("computercraft") != null)
+            ClockworkForgePeripheralProviders.register();
     }
 
     public static ResourceLocation asResource(String path) {

--- a/forge/src/main/java/org/valkyrienskies/clockwork/forge/integration/cc_restiched/ClockworkForgePeripheralProviders.java
+++ b/forge/src/main/java/org/valkyrienskies/clockwork/forge/integration/cc_restiched/ClockworkForgePeripheralProviders.java
@@ -1,0 +1,28 @@
+package org.valkyrienskies.clockwork.forge.integration.cc_restiched;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
+import org.valkyrienskies.clockwork.content.contraptions.afterblazer.AfterblazerBlockEntity;
+import org.valkyrienskies.clockwork.integration.cc.AfterblazerPeripheral;
+
+public class ClockworkForgePeripheralProviders {
+    public static void register() {
+        ComputerCraftAPI.registerPeripheralProvider(new AfterblazerPeripheralProvider());
+    }
+
+    public static class AfterblazerPeripheralProvider implements IPeripheralProvider {
+        @Override
+        public LazyOptional<IPeripheral> getPeripheral(@NotNull Level level, @NotNull BlockPos blockPos, @NotNull Direction direction) {
+            if (level.getBlockEntity(blockPos) instanceof AfterblazerBlockEntity afterblazer) {
+                return LazyOptional.of(() -> new AfterblazerPeripheral(afterblazer));
+            }
+            return LazyOptional.empty();
+        }
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/clockwork/forge/integration/cc_tweaked/CCEvents.java
+++ b/forge/src/main/java/org/valkyrienskies/clockwork/forge/integration/cc_tweaked/CCEvents.java
@@ -1,0 +1,26 @@
+package org.valkyrienskies.clockwork.forge.integration.cc_tweaked;
+
+import dan200.computercraft.shared.computer.core.ServerComputer;
+import dan200.computercraft.shared.computer.core.ServerContext;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.valkyrienskies.clockwork.content.contraptions.sequenced_seat.InputKey;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class CCEvents {
+    public static void sequencedSeatKeysUpdated(ServerLevel level, BlockPos pos, Set<InputKey> keys) {
+        List<String> stringKeys = new ArrayList<>(List.of());
+        for (InputKey key : keys) {
+            stringKeys.add(key.toString());
+        }
+
+        Set<BlockPos> possibleComputers = Set.of(pos.above(), pos.below(), pos.north(), pos.west(), pos.east(), pos.south());
+        for (ServerComputer computer : ServerContext.get(level.getServer()).registry().getComputers()) {
+            if (possibleComputers.contains(computer.getPosition()))
+                computer.queueEvent("command_seat_keys", stringKeys.toArray());
+        }
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/clockwork/forge/integration/cc_tweaked/ClockworkForgePeripheralProviders.java
+++ b/forge/src/main/java/org/valkyrienskies/clockwork/forge/integration/cc_tweaked/ClockworkForgePeripheralProviders.java
@@ -1,4 +1,4 @@
-package org.valkyrienskies.clockwork.forge.integration.cc_restiched;
+package org.valkyrienskies.clockwork.forge.integration.cc_tweaked;
 
 import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;

--- a/forge/src/main/java/org/valkyrienskies/clockwork/platform/forge/PlatformUtilsImpl.java
+++ b/forge/src/main/java/org/valkyrienskies/clockwork/platform/forge/PlatformUtilsImpl.java
@@ -3,9 +3,9 @@ package org.valkyrienskies.clockwork.platform.forge;
 import com.simibubi.create.AllTags;
 import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.behaviour.BehaviourType;
-import com.simibubi.create.foundation.tileEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -15,19 +15,21 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.network.NetworkHooks;
 import org.valkyrienskies.clockwork.content.contraptions.afterblazer.AfterblazerBlockEntity.FuelType;
 import org.valkyrienskies.clockwork.content.contraptions.ballooner.BalloonerBlockEntity;
-import org.valkyrienskies.clockwork.content.contraptions.combustion_engine.CombustionEngineBlockEntity;
+import org.valkyrienskies.clockwork.content.contraptions.sequenced_seat.InputKey;
 import org.valkyrienskies.clockwork.forge.ForgeClockworkItems;
 import org.valkyrienskies.clockwork.forge.config.AllClockworkConfigs;
 //import org.valkyrienskies.clockwork.forge.content.contraptions.combustion_engine.ForgeCombustionEngineBlockEntity;
-import org.valkyrienskies.clockwork.platform.SmartFluidTankBlockEntity;
+import org.valkyrienskies.clockwork.forge.integration.cc_tweaked.CCEvents;
 import org.valkyrienskies.clockwork.util.blocktype.EngineHeatLevel;
 import org.valkyrienskies.clockwork.util.fluid.CWFluidTankBehaviour;
+
+import java.util.Set;
 
 import static org.valkyrienskies.clockwork.content.contraptions.ballooner.BalloonerBlockEntity.INSERTION_THRESHOLD;
 import static org.valkyrienskies.clockwork.content.contraptions.ballooner.BalloonerBlockEntity.MAX_HEAT_CAPACITY;
@@ -152,4 +154,11 @@ public class PlatformUtilsImpl {
         return new ForgeCWFluidTankBehaviour(type, te, tanks, tankCapacity, enforceVariety);
     }
 
+    public static boolean isModLoaded(String modId) {
+        return FMLLoader.getLoadingModList().getModFileById(modId) != null;
+    }
+
+    public static void sequencedSeatKeysUpdated(ServerLevel level, BlockPos pos, Set<InputKey> keys) {
+        CCEvents.sequencedSeatKeysUpdated(level, pos, keys);
+    }
 }


### PR DESCRIPTION
This adds new ways for ComputerCraft computers to interact with Clockwork. It adds one peripheral and an event.

**Afterblazer Peripheral**
- Files Included:
  - AfterblazerPeripheral (Commom)
  - ClockworkFabricPeripheralProviders
  - ClockworkForgePeripheralProviders
- This peripheral allows players to retrieve and set the Gimbal on the Afterblazer using 4 methods

**Custom Events**
- Files Included:
  - CCEvents (Forge and Fabric)
  - PlatformUtils (Common, Forge, and Fabric)
    - isModLoaded()
    - sequentialSeatKeysUpdate()
  - SequentialSeatBlockEntity
    - PlatformUtils.sequentialSeatKeysUpdate() and PlatformUtils.isModLoaded() called in updateInputs()
- Whenever the keys are updated for the Command Seat, it tests for adjacent computers and queues an event names "command_seat_keys" and returns a List of InputKeys.toString()

And of course, added CC Restitched and Tweaked to the Fabric/Common and Forge build.gradles
I also added CurseMaven to the Forge build.gradle repos due to it being necessary to run