### PR TITLE
Dynamic propeller stress impact

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/propeller/PropellerBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/propeller/PropellerBearingBlockEntity.kt
@@ -42,6 +42,7 @@ import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.util.toJOMLD
 import kotlin.math.absoluteValue
 import kotlin.math.min
+import kotlin.math.sin
 
 class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockState, val brass: Boolean = false) : KineticBlockEntity(type, pos, state), IBearingBlockEntity, IForceApplierBE<PropUpdateData, PropData, PropCreateData, PropellerController> {
 
@@ -271,18 +272,11 @@ class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state
 
         if (brass) {
             getSails()
-            // Add stress impact from propeller contraption.
-            // Stress impact of propeller contraption is computed by:
-            // sum((sail relative pos from bearing).cross(bearing axis))
-            var stressImpact = 0.0
-            val axis : Vector3dc = direction.normal.toJOMLD()
-            for(sail in sailPositions) {
-                stressImpact += axis.cross(sail.x().toDouble(), sail.y().toDouble(), sail.z().toDouble(), Vector3d()).length()
-            }
-            orCreateNetwork?.updateStressFor(this, stressImpact.toFloat())
         } else {
             getBlades()
         }
+        val stressImpact = calculateStressApplied()
+        orCreateNetwork?.updateStressFor(this, stressImpact)
 
         if (!level!!.isClientSide) {
             val ship = (level as ServerLevel).getShipObjectManagingPos(
@@ -316,7 +310,8 @@ class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state
         }
 
         // Remove stress impact
-        orCreateNetwork?.updateStressFor(this, 0.0f)
+        val stressImpact = calculateStressApplied()
+        orCreateNetwork?.updateStressFor(this, stressImpact)
 
         sendData()
     }
@@ -494,5 +489,28 @@ class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state
         fun omegaToRPM(omega: Double): Float {
             return ((omega * 60.0) / (2.0 * Math.PI)).toFloat()
         }
+    }
+
+    override fun calculateStressApplied(): Float {
+        if(level!!.isClientSide) return lastStressApplied
+        var stressImpact = 0.0
+        val axis : Vector3dc = blockState.getValue(BlockStateProperties.FACING).normal.toJOMLD()
+        if (propellerContraption != null) {
+            if(brass) {
+                // Add stress impact from propeller contraption.
+                // Stress impact of propeller contraption is computed by:
+                // sum((sail relative pos from bearing).cross(bearing axis))
+                for (sail in sailPositions) {
+                    stressImpact += axis.cross(sail.x().toDouble(), sail.y().toDouble(), sail.z().toDouble(), Vector3d()).length()
+                }
+            } else {
+                // Add stress impact from propeller blades.
+                for (blade in blades) {
+                    stressImpact += blade.length * sin(Math.toRadians(blade.angle)) * (if(blade.wide) 1.5 else 1.0)
+                }
+            }
+        }
+        lastStressApplied = stressImpact.toFloat()
+        return stressImpact.toFloat()
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/propeller/PropellerBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/propeller/PropellerBearingBlockEntity.kt
@@ -22,6 +22,9 @@ import net.minecraft.util.Mth
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.properties.BlockStateProperties
+import org.joml.Vector3d
+import org.joml.Vector3dc
+import org.joml.Vector3i
 import org.joml.Vector3ic
 import org.valkyrienskies.clockwork.ClockworkBlocks
 import org.valkyrienskies.clockwork.ClockworkLang
@@ -37,9 +40,7 @@ import org.valkyrienskies.clockwork.content.generic.IForceApplierBE
 import org.valkyrienskies.mod.common.getShipObjectManagingPos
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.util.toJOMLD
-import kotlin.math.abs
 import kotlin.math.absoluteValue
-import kotlin.math.max
 import kotlin.math.min
 
 class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockState, val brass: Boolean = false) : KineticBlockEntity(type, pos, state), IBearingBlockEntity, IForceApplierBE<PropUpdateData, PropData, PropCreateData, PropellerController> {
@@ -270,6 +271,15 @@ class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state
 
         if (brass) {
             getSails()
+            // Add stress impact from propeller contraption.
+            // Stress impact of propeller contraption is computed by:
+            // sum((sail relative pos from bearing).cross(bearing axis))
+            var stressImpact = 0.0
+            val axis : Vector3dc = direction.normal.toJOMLD()
+            for(sail in sailPositions) {
+                stressImpact += axis.cross(sail.x().toDouble(), sail.y().toDouble(), sail.z().toDouble(), Vector3d()).length()
+            }
+            orCreateNetwork?.updateStressFor(this, stressImpact.toFloat())
         } else {
             getBlades()
         }
@@ -304,6 +314,10 @@ class PropellerBearingBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state
         if (physID != -1) {
             removeApplier(PropellerController::class.java, level, worldPosition)
         }
+
+        // Remove stress impact
+        orCreateNetwork?.updateStressFor(this, 0.0f)
+
         sendData()
     }
 


### PR DESCRIPTION
- Propeller bearings have dynamic stress impact value, calulated by:
    - Brass bearing : proportional to sum of sail-like blocks distance from propeller axis.
    - Andesite bearing: proportional to sum of propeller blade length, and wide blades have additional modifier.
- Haven't done balance test, so it might need adjusted modifier or config for the values.