### PR TITLE
Rewrite Reaction wheel logic to function as intended

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/forces/ReactionWheelController.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/forces/ReactionWheelController.kt
@@ -2,26 +2,17 @@ package org.valkyrienskies.clockwork.content.forces
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonIgnore
-import net.minecraft.util.Mth
-import org.joml.Matrix3d
 import org.joml.Vector3d
 import org.joml.Vector3dc
-import org.joml.Vector3ic
 import org.valkyrienskies.clockwork.ClockworkConfig
 import org.valkyrienskies.clockwork.content.physicalities.reactionwheel.data.ReactionWheelCreateData
 import org.valkyrienskies.clockwork.content.physicalities.reactionwheel.data.ReactionWheelData
 import org.valkyrienskies.clockwork.content.physicalities.reactionwheel.data.ReactionWheelUpdateData
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.core.api.ships.PhysShip
-import org.valkyrienskies.core.api.ships.ServerShip
-import org.valkyrienskies.core.api.ships.setAttachment
 import org.valkyrienskies.core.api.world.PhysLevel
 import org.valkyrienskies.core.impl.game.ships.PhysShipImpl
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
-import kotlin.math.absoluteValue
-import kotlin.math.min
-import kotlin.math.sign
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 class ReactionWheelController(
@@ -41,58 +32,38 @@ class ReactionWheelController(
         super.physTick(physShip, physLevel)
 
         for (wheelID in appliers.keys) {
-            val (torque, deltaWheelOmega) = conserveMomentum(physShip as PhysShipImpl, appliers[wheelID]!!)
+            val (torque, torque2) = conserveMomentum(physShip as PhysShipImpl, appliers[wheelID]!!)
             if (torque.isFinite && !torque.length().isNaN()) {
                 physShip.applyWorldTorque(torque)
-                pendingMomentumConsumptionQueue[wheelID]?.add(deltaWheelOmega) ?: run {
-                    pendingMomentumConsumptionQueue[wheelID] = ConcurrentLinkedQueue()
-                    pendingMomentumConsumptionQueue[wheelID]?.add(deltaWheelOmega)
-                }
+                physShip.applyWorldTorque(torque2)
             }
         }
 
         previousTickShipOmega = physShip.omega
     }
 
-    fun conserveMomentum(physShip: PhysShipImpl, wheel: ReactionWheelData): Pair<Vector3d, Double> {
+    fun conserveMomentum(physShip: PhysShipImpl, wheel: ReactionWheelData): Pair<Vector3dc, Vector3dc> {
         val wheelPos: Vector3dc = Vector3d(wheel.position!!)
         val wheelDir: Vector3dc = Vector3d(wheel.direction!!)
-        val realAxis: Vector3dc = physShip.transform.shipToWorld.transformDirection(wheelDir, Vector3d()).normalize()
+        val wheelAxisInWorld: Vector3dc = physShip.transform.shipToWorld.transformDirection(wheelDir, Vector3d()).normalize()
 
         val wheelSpeed = wheel.currentRPM / 60.0 * 2.0 * Math.PI
         val wheelPrevious = wheel.previousRPM / 60.0 * 2.0 * Math.PI
 
-        val wheelMass = ClockworkConfig.SERVER.reactionWheelEffectiveness * 32000.0
+        val wheelMass = ClockworkConfig.SERVER.reactionWheelEffectiveness * 1_920_000.0.coerceAtMost(9600 * physShip.mass)
+        // 1/2 * m * (r_2^2 + r_1^2)
         val wheelInertia = (0.5 * wheelMass) * (Math.pow(0.25, 2.0) + Math.pow(0.75, 2.0))
+        // 1/12 * m * (3 * (r_2^2 + r_1^2) + h^2)
+        val offAxisInertia = (1/12.0 * wheelMass) * (3*(Math.pow(0.25, 2.0) + Math.pow(0.75, 2.0)) + Math.pow(0.5, 2.0))
 
-        val wheelOmega = realAxis.mul(wheelSpeed, Vector3d())
-        val wheelPreviousOmega = realAxis.mul(wheelPrevious, Vector3d())
+        val newW: Vector3dc = wheelAxisInWorld.mul(wheelSpeed, Vector3d())
+        val deltaW: Vector3dc = newW.normalize(Vector3d()).cross(physShip.angularVelocity.div( 60.0, Vector3d()), Vector3d())
 
-        val deltaWheelOmega = wheelSpeed - wheelPrevious
+        val axialTorque = wheelAxisInWorld.mul((wheelSpeed - wheelPrevious) * wheelInertia / 20.0, Vector3d())
 
-        val wheelL: Vector3dc = wheelOmega.mul(wheelInertia)
-        val wheelPreviousL: Vector3dc = wheelPreviousOmega.mul(wheelInertia)
+        val torqueInduced: Vector3dc = deltaW.mul(offAxisInertia, Vector3d())
 
-        val shipL: Vector3dc = realAxis.mul(physShip.omega.dot(realAxis), Vector3d()).mul(physShip.momentOfInertia)
-        val previousShipL: Vector3dc = realAxis.mul(previousTickShipOmega.dot(realAxis), Vector3d()).mul(physShip.momentOfInertia)
-
-        val deltaShipL = shipL.sub(previousShipL, Vector3d())
-
-        val requiredChangeInWheel = deltaShipL.div(wheelInertia, Vector3d()).mul(-1.0, Vector3d()).length()
-
-        val actualChangeInWheel = Mth.clamp(Mth.clamp(requiredChangeInWheel, -(wheelL.length().absoluteValue / wheelInertia), (wheelL.length().absoluteValue / wheelInertia)), -1024.0 - wheelSpeed, 1024.0 - wheelSpeed)
-
-        val leftoverShipL: Vector3dc = shipL.sub(realAxis.mul((deltaWheelOmega + actualChangeInWheel) * 10.0 * wheelInertia, Vector3d()), Vector3d())
-
-        val changeInShipL = shipL.sub(leftoverShipL, Vector3d())
-
-        val torque = changeInShipL.mul(1.0, Vector3d())
-
-        wheel.pushRPM(wheel.currentRPM)
-
-        //ClockworkMod.LOGGER.info("Torque: $torque, Delta Wheel Omega: $actualChangeInWheel")
-
-        return torque to actualChangeInWheel
+        return torqueInduced to axialTorque
     }
 
     companion object {

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/reactionwheel/ReactionWheelBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/reactionwheel/ReactionWheelBlockEntity.kt
@@ -61,21 +61,7 @@ class ReactionWheelBlockEntity(typeIn: BlockEntityType<*>, pos: BlockPos, state:
     }
 
     private fun calculateTargetSpeed(): Double {
-        val ship = (level as ServerLevel).getShipObjectManagingPos(worldPosition)
-        if (ship != null) {
-            val attachment = ReactionWheelController.getOrCreate(ship!!)
-            if (attachment != null && physID >= 0) {
-                if (attachment.pendingMomentumConsumptionQueue.isNotEmpty()) {
-                    targetSpeed = attachment.pendingMomentumConsumptionQueue[physID]?.poll() ?: 0.0
-                }
-            }
-        }
-
-        return if (getSpeed() != 0f) {
-            Mth.clamp(targetSpeed + (getSpeed().toDouble() / 2.0), -1024.0, 1024.0)
-        } else {
-            targetSpeed
-        }
+        return getSpeed().toDouble()
     }
 
     override fun tick() {

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/reactionwheel/data/ReactionWheelData.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/reactionwheel/data/ReactionWheelData.kt
@@ -16,6 +16,7 @@ class ReactionWheelData: ForceApplierData<ReactionWheelUpdateData> {
 
 
     override fun updateData(data: ReactionWheelUpdateData) {
+        this.previousRPM = this.currentRPM
         this.currentRPM = data.currentSpeed
     }
 
@@ -30,9 +31,5 @@ class ReactionWheelData: ForceApplierData<ReactionWheelUpdateData> {
     constructor() {
         this.position = null
         this.direction = null
-    }
-
-    fun pushRPM(rpm: Double) {
-        previousRPM = rpm
     }
 }


### PR DESCRIPTION
Change reaction wheel logic to be physically accurate based on the following axioms:
- A ship's angular momentum is conserved by the physics engine
- The change in the angular momentum of a ship is not easily reversible

As such, this new logic ignores the ship (except for its angular velocity) in favor of the reaction wheel by itself. It computes the induced torque due to conservation law, based on the change in angular momentum (of the wheel). It does this in separate axial and non-axial components for clarity.

The logic which allowed momentum to cause a change in RPM of the reaction wheel was removed as conservation laws are assumed. The reaction wheel now simply chases towards the input RPM (or zero, if there is no input).