### PR TITLE
Change gyro physics to ignore own plane of rotation

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/gyro/GyroBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/gyro/GyroBlockEntity.kt
@@ -11,6 +11,7 @@ import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
 import org.joml.Quaterniond
+import org.joml.Vector3d
 import org.valkyrienskies.clockwork.content.physicalities.IClockworkWheelBE
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.mod.common.getShipObjectManagingPos
@@ -28,7 +29,7 @@ class GyroBlockEntity(typeIn: BlockEntityType<*>?, pos: BlockPos, state: BlockSt
     var coreAngle = 0f
     var previousCoreAngle = 0f
 
-    var targetQuat: Quaterniond = Quaterniond(0.0,1.0,0.0,0.0)
+    var targetVec: Vector3d = Vector3d(0.0,1.0,0.0)
     private val ship: LoadedServerShip? get() = (level as ServerLevel).getShipObjectManagingPos(this.blockPos)
     private val control: GyroShipControl? get() = ship?.getAttachment(GyroShipControl::class.java)
 
@@ -48,16 +49,19 @@ class GyroBlockEntity(typeIn: BlockEntityType<*>?, pos: BlockPos, state: BlockSt
             return
         }
 
+        updatePower(level!!, blockPos)
+
+        val up = Vector3d(0.0, 1.0, 0.0)
+        up.rotateX((redstonePower.x / 15.0) * Math.PI/2)
+        up.rotateZ((redstonePower.y / 15.0) * Math.PI/2)
+        targetVec = up
+
         if (level is ServerLevel) {
             control?.ship = ship
             control?.speed = getSpeed()
-            control?.pointTowards(targetQuat, 1.0f)
+            control?.pointTowards(targetVec, 1.0f)
         }
 
-        updatePower(level!!, blockPos)
-
-        targetQuat.x = (redstonePower.x / 15.0) / 2
-        targetQuat.z = (redstonePower.y / 15.0) / 2
         val targetSpeed = getSpeed()
         visualSpeed.updateChaseTarget(targetSpeed)
         visualSpeed.tickChaser()
@@ -85,10 +89,9 @@ class GyroBlockEntity(typeIn: BlockEntityType<*>?, pos: BlockPos, state: BlockSt
 
     public override fun write(compound: CompoundTag, clientPacket: Boolean) {
         super.write(compound, clientPacket)
-        compound.putDouble("X", targetQuat.x())
-        compound.putDouble("Y", targetQuat.y())
-        compound.putDouble("Z", targetQuat.z())
-        compound.putDouble("W", targetQuat.w())
+        compound.putDouble("X", targetVec.x())
+        compound.putDouble("Y", targetVec.y())
+        compound.putDouble("Z", targetVec.z())
 
         compound.putInt("PowerX", redstonePower.x)
         compound.putInt("PowerZ", redstonePower.y)
@@ -96,7 +99,7 @@ class GyroBlockEntity(typeIn: BlockEntityType<*>?, pos: BlockPos, state: BlockSt
 
     public override fun read(compound: CompoundTag, clientPacket: Boolean) {
         if (compound.contains("X")) {
-            targetQuat = Quaterniond(compound.getDouble("X"), compound.getDouble("Y"), compound.getDouble("Z"), compound.getDouble("Z"))
+            targetVec = Vector3d(compound.getDouble("X"), compound.getDouble("Y"), compound.getDouble("Z"))
         }
         if (compound.contains("PowerX")) {
             redstonePower = Point(compound.getInt("PowerX"), compound.getInt("PowerXZ"))

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/gyro/GyroShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/gyro/GyroShipControl.kt
@@ -5,14 +5,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.joml.Quaterniond
 import org.joml.Vector3d
-import org.valkyrienskies.core.api.VsBeta
 import org.valkyrienskies.core.api.attachment.getAttachment
 import org.valkyrienskies.core.api.attachment.removeAttachment
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.core.api.ships.PhysShip
 import org.valkyrienskies.core.api.ships.ServerTickListener
 import org.valkyrienskies.core.api.ships.ShipPhysicsListener
-import org.valkyrienskies.core.api.util.PhysTickOnly
 import org.valkyrienskies.core.api.world.PhysLevel
 import kotlin.math.abs
 import kotlin.math.exp
@@ -45,44 +43,29 @@ class GyroShipControl : ShipPhysicsListener, ServerTickListener {
 
     internal var speed: Float = 0f
 
-    @OptIn(PhysTickOnly::class)
     override fun physTick(physShip: PhysShip, physLevel: PhysLevel) {
-        // region 70% chatGPT code but it somehow works
-        if (gyros < 1) return
+        if (gyros < 1) {
+            return
+        }
 
-        val transform = physShip.transform
+        val rotDif = targetRotation
+            .mul(physShip.transform.shipToWorldRotation.invert(Quaterniond()), Quaterniond())
+            .normalize().invert()
 
-        // Worldspace "up" to shipspace up
-        val correctionAxis = transform.shipToWorldRotation
-            .transform(Vector3d(0.0, 1.0, 0.0))
-            .normalize()
+        // Blackmagic ask triode
+        val idealOmega = Vector3d(rotDif.x() * 2.0, rotDif.y() * 2.0, rotDif.z() * 2.0)
+        if (rotDif.w() > 0) idealOmega.mul(-1.0)
 
-        val errorMagnitude = correctionAxis.length()
-        if (errorMagnitude < 1e-6) return
+        idealOmega.sub(physShip.omega)
 
-        correctionAxis.normalize()
-
-        // Proportional correction (acts like a PD controller)
-        val correctionStrength = errorMagnitude * 2.0
-
-        val idealOmega = correctionAxis.mul(correctionStrength)
-
-        // Damping using current angular velocity
-        idealOmega.sub(physShip.angularVelocity)
-
-        // Convert angular correction to torque
-        val idealTorque = transform.shipToWorldRotation.transform(
+        val idealTorque = physShip.transform.shipToWorldRotation.transform(
             physShip.momentOfInertia.transform(
-                transform.shipToWorldRotation.transformInverse(idealOmega, Vector3d())
-            )
-        )
+                physShip.transform.shipToWorldRotation.transformInverse(idealOmega, Vector3d())))
 
         idealTorque.mul(abs(speedToForce(speed)))
 
-        physShip.applyWorldTorque(idealTorque)
-        // endregion
+        physShip.applyInvariantTorque(idealTorque)
     }
-
 
     private fun speedToForce(speed: Float): Double {
         val y = 128.0 / (1 + exp(6 - (speed * 0.05)))

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/gyro/GyroShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/gyro/GyroShipControl.kt
@@ -3,8 +3,10 @@ package org.valkyrienskies.clockwork.content.physicalities.gyro
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import net.fabricmc.loader.impl.lib.sat4j.core.Vec
 import org.joml.Quaterniond
 import org.joml.Vector3d
+import org.joml.Vector3dc
 import org.valkyrienskies.core.api.attachment.getAttachment
 import org.valkyrienskies.core.api.attachment.removeAttachment
 import org.valkyrienskies.core.api.ships.LoadedServerShip
@@ -12,6 +14,8 @@ import org.valkyrienskies.core.api.ships.PhysShip
 import org.valkyrienskies.core.api.ships.ServerTickListener
 import org.valkyrienskies.core.api.ships.ShipPhysicsListener
 import org.valkyrienskies.core.api.world.PhysLevel
+import org.valkyrienskies.core.impl.shadow.fr
+import org.valkyrienskies.core.impl.shadow.id
 import kotlin.math.abs
 import kotlin.math.exp
 
@@ -24,7 +28,7 @@ import kotlin.math.exp
 @JsonIgnoreProperties(ignoreUnknown = true)
 class GyroShipControl : ShipPhysicsListener, ServerTickListener {
 
-    private var targetRotation = Quaterniond()
+    private var targetUp: Vector3dc = Vector3d()
     private var targetStrength = 1.0f
     private var physConsumption = 0f
     private var extraForceLinear = 0.0
@@ -48,15 +52,10 @@ class GyroShipControl : ShipPhysicsListener, ServerTickListener {
             return
         }
 
-        val rotDif = targetRotation
-            .mul(physShip.transform.shipToWorldRotation.invert(Quaterniond()), Quaterniond())
-            .normalize().invert()
-
-        // Blackmagic ask triode
-        val idealOmega = Vector3d(rotDif.x() * 2.0, rotDif.y() * 2.0, rotDif.z() * 2.0)
-        if (rotDif.w() > 0) idealOmega.mul(-1.0)
-
-        idealOmega.sub(physShip.omega)
+        val shipWorldUp: Vector3dc = physShip.transform.shipToWorldRotation.transform(Vector3d(0.0,1.0,0.0))
+        val offAxisOmega = physShip.angularVelocity.sub(
+            shipWorldUp.normalize(physShip.angularVelocity.dot(shipWorldUp), Vector3d()), Vector3d())
+        val idealOmega = shipWorldUp.cross(targetUp, Vector3d()).sub(offAxisOmega)
 
         val idealTorque = physShip.transform.shipToWorldRotation.transform(
             physShip.momentOfInertia.transform(
@@ -64,7 +63,7 @@ class GyroShipControl : ShipPhysicsListener, ServerTickListener {
 
         idealTorque.mul(abs(speedToForce(speed)))
 
-        physShip.applyInvariantTorque(idealTorque)
+        physShip.applyWorldTorque(idealTorque)
     }
 
     private fun speedToForce(speed: Float): Double {
@@ -78,9 +77,8 @@ class GyroShipControl : ShipPhysicsListener, ServerTickListener {
         }
     }
 
-    fun pointTowards(targetRotation: Quaterniond, power: Float) {
-        //val axis = seatDir.normal.toJOMLD().cross(targetDirection, Vector3d())
-        this.targetRotation = targetRotation//Quaterniond(AxisAngle4d(seatDir.normal.toJOMLD().angle(targetDirection), axis)).normalize()
+    fun pointTowards(targetUp: Vector3dc, power: Float) {
+        this.targetUp = targetUp//Quaterniond(AxisAngle4d(seatDir.normal.toJOMLD().angle(targetDirection), axis)).normalize()
         this.targetStrength = power
     }
 


### PR DESCRIPTION
Modified the gyro controller to apply a torque that aligns the up axis of the ship with the target axis (world up), thus allowing the ship to freely rotate along this plane (ie. allowing yaw when a gyro is set to upward stabilisation).

Additionally changed redstone target axis logic to be mathematically sound.