### PR TITLE
Rendering fixes

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkBlocks.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkBlocks.kt
@@ -91,7 +91,7 @@ object ClockworkBlocks {
         }
             .initialProperties(AllBlocks.BELT)
             .transform(axeOrPickaxe())
-            .properties { it.instabreak().explosionResistance(0f) }
+            .properties { it.instabreak().explosionResistance(0f).noOcclusion() }
             .addLayer { Supplier { RenderType.cutout() } }
             .tag(AllTags.AllBlockTags.SAFE_NBT.tag)
             .item()

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/kinetics/universal_shaft/UniversalShaftRenderer.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/kinetics/universal_shaft/UniversalShaftRenderer.kt
@@ -26,12 +26,10 @@ import org.joml.Matrix4f
 import org.joml.Vector3d
 import org.lwjgl.opengl.GL11
 import org.valkyrienskies.clockwork.ClockworkMod
-import org.valkyrienskies.clockwork.content.physicalities.extendon.ExtendonRenderer
 import org.valkyrienskies.clockwork.util.minus
 import org.valkyrienskies.clockwork.util.plus
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.mod.common.getShipManagingPos
-import org.valkyrienskies.mod.common.toWorldCoordinates
 import org.valkyrienskies.mod.common.util.toJOMLD
 import kotlin.math.PI
 import kotlin.math.atan2
@@ -57,6 +55,8 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
 
         val speed: Float = be.speed
 
+        val tubeBuffer = buffer.getBuffer(RenderType.entitySolid(texture))
+
         if (be.connectedBe != null) {
             val thisShip = be.level!!.getShipManagingPos(be.blockPos) as ClientShip?
             val thisPos = if (thisShip == null) be.blockPos.toJOMLD() + 0.5 else thisShip.renderTransform.shipToWorld.transformPosition(be.blockPos.toJOMLD() + 0.5)!!
@@ -81,7 +81,7 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
                 val roll = getAngleForBe(be, be.pos, be.blockState.getValue<Direction>(BlockStateProperties.FACING).axis)
                 val realAngles = Triple(angles.first, angles.second, roll.toDouble())
 
-                renderTubes(direction.length().toFloat() * tubeLengthMultiplier, ms, realAngles, be.blockPos, be.connectedBe!!.blockPos, tubeRadiusMultiplier, tubeTextureMultiplier)
+                renderTubes(direction.length().toFloat() * tubeLengthMultiplier, ms, realAngles, be.blockPos, be.connectedBe!!.blockPos, tubeRadiusMultiplier, tubeTextureMultiplier, tubeBuffer)
             }
         }
 
@@ -98,6 +98,7 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
         pos1: BlockPos, pos2: BlockPos,
         tubeRadiusScale: Float,
         tubeLengthScale: Float,
+        buffer: VertexConsumer
     ) {
         val (pitch, yaw, roll) = angles
         val level = Minecraft.getInstance().level!!
@@ -107,9 +108,9 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
         chain.center();
 
         chain.rotateY(yaw.toFloat())
-        chain.rotateX((-pitch).toFloat())
+        chain.rotateX(-pitch.toFloat())
         chain.rotateY(-roll.toFloat())
-        chain.rotateY((PI / 4.0f).toFloat())
+        //chain.rotateY((PI / 4.0f).toFloat())
 
 
         chain.translate(0.5, 8 / 16.0, 0.5)
@@ -117,7 +118,7 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
 
         //==========
 
-        val radius = 6f / 16f / 2f * tubeRadiusScale
+        val radius = 6f / 16f / 2f * tubeRadiusScale / sqrt(2f)
 
         val minU = 0f
         val maxU = 1f
@@ -133,33 +134,12 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
             level.getBrightness(LightLayer.SKY, pos2)
         )
 
-        //stupidity
-        val tesselator = Tesselator.getInstance()
-        val buf = tesselator.builder
-
-        RenderSystem.disableBlend()
-        RenderSystem.disableCull()
-        RenderSystem.enableDepthTest()
-        RenderSystem.depthFunc(GL11.GL_LEQUAL)
-        RenderSystem.depthMask(true)
-        RenderSystem.setShader(GameRenderer::getRendertypeTranslucentShader)
-        RenderSystem.setShaderTexture(0, texture)
-
-        Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer()
-
-        buf.begin(VertexFormat.Mode.QUADS, GameRenderer.getRendertypeTranslucentShader()!!.vertexFormat)
-
-        renderPart(buf, ms, length,
-            0f, radius, -radius, 0f,
-            radius, 0f, 0f, -radius,
+        renderPart(buffer, ms, length,
+            radius, radius, -radius, -radius,
+            radius, -radius, radius, -radius,
             minU, maxU, minV, maxV,
             light1, light2
         )
-
-        tesselator.end()
-
-        RenderSystem.enableBlend()
-        RenderSystem.enableCull()
 
         //==========
 
@@ -180,10 +160,10 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
         val matrix = pose.pose()
         val normal = pose.normal()
 
-        renderQuad(buf, matrix, normal, 0f, maxY, x0, x2, z0, z2, minU, maxU, minV, maxV, light1, light2)
-        renderQuad(buf, matrix, normal, 0f, maxY, x1, x0, z1, z0, minU, maxU, minV, maxV, light1, light2)
-        renderQuad(buf, matrix, normal, 0f, maxY, x3, x1, z3, z1, minU, maxU, minV, maxV, light1, light2)
-        renderQuad(buf, matrix, normal, 0f, maxY, x2, x3, z2, z3, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x2, x0, z2, z0, 0f, 0f, 1f, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x0, x1, z0, z1, 1f, 0f, 0f, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x1, x3, z1, z3, 0f, 0f, -1f, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x3, x2, z3, z2, -1f, 0f, 0f, minU, maxU, minV, maxV, light1, light2)
     }
 
     fun renderQuad(
@@ -193,14 +173,15 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
         minY: Float, maxY: Float,
         minX: Float, maxX: Float,
         minZ: Float, maxZ: Float,
+        normalX: Float, normalY: Float, normalZ: Float,
         minU: Float, maxU: Float,
         minV: Float, maxV: Float,
         light1: Int, light2: Int
     ) {
-        addVertex(buf, matrix, normal, minX, maxY, minZ, maxU, minV, light2)
-        addVertex(buf, matrix, normal, minX, minY, minZ, maxU, maxV, light1)
-        addVertex(buf, matrix, normal, maxX, minY, maxZ, minU, maxV, light1)
-        addVertex(buf, matrix, normal, maxX, maxY, maxZ, minU, minV, light2)
+        addVertex(buf, matrix, normal, minX, maxY, minZ, normalX, normalY, normalZ, maxU, minV, light2)
+        addVertex(buf, matrix, normal, minX, minY, minZ, normalX, normalY, normalZ, maxU, maxV, light1)
+        addVertex(buf, matrix, normal, maxX, minY, maxZ, normalX, normalY, normalZ, minU, maxV, light1)
+        addVertex(buf, matrix, normal, maxX, maxY, maxZ, normalX, normalY, normalZ, minU, minV, light2)
     }
 
     fun addVertex(
@@ -208,6 +189,7 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
         matrix: Matrix4f,
         normal: Matrix3f,
         x: Float, y: Float, z: Float,
+        normalX: Float, normalY: Float, normalZ: Float,
         u: Float, v: Float,
         light: Int,
     ) = buf
@@ -216,7 +198,7 @@ class UniversalShaftRenderer(context: BlockEntityRendererProvider.Context?) : Ki
         .uv(u, v)
         .overlayCoords(OverlayTexture.NO_OVERLAY)
         .uv2(light)
-        .normal(normal, 0f, 1f, 0f)
+        .normal(normal, normalX, normalY, normalZ)
         .endVertex()
 
     companion object {

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/extendon/ExtendonRenderer.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/physicalities/extendon/ExtendonRenderer.kt
@@ -1,19 +1,12 @@
 package org.valkyrienskies.clockwork.content.physicalities.extendon
 
-import com.mojang.blaze3d.systems.RenderSystem
 import com.mojang.blaze3d.vertex.PoseStack
-import com.mojang.blaze3d.vertex.Tesselator
 import com.mojang.blaze3d.vertex.VertexConsumer
-import com.mojang.blaze3d.vertex.VertexFormat
-import com.simibubi.create.content.logistics.depot.EjectorRenderer
 import com.simibubi.create.foundation.blockEntity.renderer.SmartBlockEntityRenderer
 import dev.engine_room.flywheel.lib.transform.TransformStack
-import net.createmod.catnip.outliner.Outline
-import net.createmod.catnip.outliner.Outliner
 import net.createmod.catnip.render.CachedBuffers
 import net.createmod.catnip.render.SuperByteBuffer
 import net.minecraft.client.Minecraft
-import net.minecraft.client.renderer.GameRenderer
 import net.minecraft.client.renderer.LightTexture
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.RenderType
@@ -27,7 +20,6 @@ import net.minecraft.world.phys.Vec3
 import org.joml.Matrix3f
 import org.joml.Matrix4f
 import org.joml.Vector3d
-import org.lwjgl.opengl.GL11
 import org.valkyrienskies.clockwork.ClockworkMod
 import org.valkyrienskies.clockwork.ClockworkPartials
 import org.valkyrienskies.core.api.ships.ClientShip
@@ -51,6 +43,7 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
         overlay: Int
     ) {
         val vb = buffer.getBuffer(RenderType.cutout())
+        val tubebuffer = buffer.getBuffer(RenderType.entitySolid(texture))
 
         var axis0 = CachedBuffers.partial(ClockworkPartials.EXTENDON_AXIS0,be.blockState)
         var axis1 = CachedBuffers.partial(ClockworkPartials.EXTENDON_AXIS1,be.blockState)
@@ -80,7 +73,7 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
                 val tubeLengthMultiplier = (1.0 / mainScale).toFloat()
                 val tubeTextureMultiplier = if (otherScale > mainScale) 1f else (otherScale / mainScale).toFloat()
 
-                renderTubes(direction.length().toFloat() * tubeLengthMultiplier, ms, angles, be.blockPos, be.connectedBe!!.blockPos, tubeRadiusMultiplier, tubeTextureMultiplier)
+                renderTubes(direction.length().toFloat() * tubeLengthMultiplier, ms, angles, be.blockPos, be.connectedBe!!.blockPos, tubeRadiusMultiplier, tubeTextureMultiplier, tubebuffer)
             }
         }
 
@@ -96,6 +89,7 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
                     pos1: BlockPos, pos2: BlockPos,
                     tubeRadiusScale: Float,
                     tubeLengthScale: Float,
+                    buffer: VertexConsumer
                     ) {
         val (pitch, yaw, roll) = angles
         val level = Minecraft.getInstance().level!!
@@ -106,14 +100,13 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
 
         chain.rotateY(yaw.toFloat())
         chain.rotateX((-pitch).toFloat())
-        chain.rotateY((PI / 4.0f).toFloat())
 
         chain.translate(0.5, 8 / 16.0, 0.5)
         chain.uncenter()
 
         //==========
 
-        val radius = 13f / 16f / 2f * tubeRadiusScale
+        val radius = 13f / 16f / 2f * tubeRadiusScale / sqrt(2f)
 
         val minU = 0f
         val maxU = 1f
@@ -129,33 +122,12 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
             level.getBrightness(LightLayer.SKY, pos2)
         )
 
-        //stupidity
-        val tesselator = Tesselator.getInstance()
-        val buf = tesselator.builder
-
-        RenderSystem.disableBlend()
-        RenderSystem.disableCull()
-        RenderSystem.enableDepthTest()
-        RenderSystem.depthFunc(GL11.GL_LEQUAL)
-        RenderSystem.depthMask(true)
-        RenderSystem.setShader(GameRenderer::getRendertypeTranslucentShader)
-        RenderSystem.setShaderTexture(0, texture)
-
-        Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer()
-
-        buf.begin(VertexFormat.Mode.QUADS, GameRenderer.getRendertypeTranslucentShader()!!.vertexFormat)
-
-        renderPart(buf, ms, length,
-            0f, radius, -radius, 0f,
-            radius, 0f, 0f, -radius,
+        renderPart(buffer, ms, length,
+            radius, radius, -radius, -radius,
+            radius, -radius, radius, -radius,
             minU, maxU, minV, maxV,
             light1, light2
         )
-
-        tesselator.end()
-
-        RenderSystem.enableBlend()
-        RenderSystem.enableCull()
 
         //==========
 
@@ -176,10 +148,10 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
         val matrix = pose.pose()
         val normal = pose.normal()
 
-        renderQuad(buf, matrix, normal, 0f, maxY, x0, x2, z0, z2, minU, maxU, minV, maxV, light1, light2)
-        renderQuad(buf, matrix, normal, 0f, maxY, x1, x0, z1, z0, minU, maxU, minV, maxV, light1, light2)
-        renderQuad(buf, matrix, normal, 0f, maxY, x3, x1, z3, z1, minU, maxU, minV, maxV, light1, light2)
-        renderQuad(buf, matrix, normal, 0f, maxY, x2, x3, z2, z3, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x2, x0, z2, z0, 0f, 0f, 1f, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x0, x1, z0, z1, 1f, 0f, 0f, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x1, x3, z1, z3, 0f, 0f, -1f, minU, maxU, minV, maxV, light1, light2)
+        renderQuad(buf, matrix, normal, 0f, maxY, x3, x2, z3, z2, -1f, 0f, 0f, minU, maxU, minV, maxV, light1, light2)
     }
 
     fun renderQuad(
@@ -189,14 +161,15 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
         minY: Float, maxY: Float,
         minX: Float, maxX: Float,
         minZ: Float, maxZ: Float,
+        normalX: Float, normalY: Float, normalZ: Float,
         minU: Float, maxU: Float,
         minV: Float, maxV: Float,
         light1: Int, light2: Int
     ) {
-        addVertex(buf, matrix, normal, minX, maxY, minZ, maxU, minV, light2)
-        addVertex(buf, matrix, normal, minX, minY, minZ, maxU, maxV, light1)
-        addVertex(buf, matrix, normal, maxX, minY, maxZ, minU, maxV, light1)
-        addVertex(buf, matrix, normal, maxX, maxY, maxZ, minU, minV, light2)
+        addVertex(buf, matrix, normal, minX, maxY, minZ, normalX, normalY, normalZ, maxU, minV, light2)
+        addVertex(buf, matrix, normal, minX, minY, minZ, normalX, normalY, normalZ, maxU, maxV, light1)
+        addVertex(buf, matrix, normal, maxX, minY, maxZ, normalX, normalY, normalZ, minU, maxV, light1)
+        addVertex(buf, matrix, normal, maxX, maxY, maxZ, normalX, normalY, normalZ, minU, minV, light2)
     }
 
     fun addVertex(
@@ -204,6 +177,7 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
         matrix: Matrix4f,
         normal: Matrix3f,
         x: Float, y: Float, z: Float,
+        normalX: Float, normalY: Float, normalZ: Float,
         u: Float, v: Float,
         light: Int,
     ) = buf
@@ -212,7 +186,7 @@ class ExtendonRenderer(context: BlockEntityRendererProvider.Context?) : SmartBlo
         .uv(u, v)
         .overlayCoords(OverlayTexture.NO_OVERLAY)
         .uv2(light)
-        .normal(normal, 0f, 1f, 0f)
+        .normal(normal, normalX, normalY, normalZ)
         .endVertex()
 
     companion object {


### PR DESCRIPTION
- Lighting on sugar rockets are fixed.
- Extendons and Universal Shafts fixed.
    - Crashing on using shaders: Used existing render buffer instead of creating one from tesselator.
    - Shade being weird: Corrected normal vector.