### PR TITLE
Exhausts now create air currents (similar to encased fans)

### DIFF
--- a/common/src/main/java/org/valkyrienskies/clockwork/mixin/content/exhaust/MixinAirCurrent.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/mixin/content/exhaust/MixinAirCurrent.java
@@ -1,18 +1,31 @@
 package org.valkyrienskies.clockwork.mixin.content.exhaust;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.simibubi.create.content.kinetics.fan.AirCurrent;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
+import net.createmod.catnip.config.ConfigBase;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.valkyrienskies.clockwork.ClockworkConfig;
 import org.valkyrienskies.clockwork.mixinduck.MixinAirCurrentDuck;
 
 @Mixin(value = AirCurrent.class, remap = false)
 public class MixinAirCurrent implements MixinAirCurrentDuck {
     @Unique
+    boolean vs_clockwork$disabledParticles = false;
+    @Unique
     FanProcessingType vs_clockwork$ownProcessingType = null;
+
+    // For disabling airflow particles we ensure the random check always fails
+    @WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/createmod/catnip/config/ConfigBase$ConfigFloat;get()Ljava/lang/Object;"))
+    private Object replaceWithInf(ConfigBase.ConfigFloat instance, Operation<Object> original) {
+        if (vs_clockwork$disabledParticles) return Double.NEGATIVE_INFINITY;
+        return original.call(instance);
+    }
 
     @ModifyVariable(method = "rebuild", at = @At("STORE"), name = "type")
     private FanProcessingType applyOwnProcessingType(FanProcessingType type) {
@@ -21,9 +34,14 @@ public class MixinAirCurrent implements MixinAirCurrentDuck {
 
     @Override
     public FanProcessingType getProcessingTypeFor(double temperature) {
-        if (temperature < 400) return null;
-        if (temperature < 700) return AllFanProcessingTypes.SMOKING;
-        return AllFanProcessingTypes.BLASTING;
+        if (temperature >= ClockworkConfig.SERVER.getBulkBlastingTemp()) return AllFanProcessingTypes.BLASTING;
+        if (temperature >= ClockworkConfig.SERVER.getBulkSmokingTemp()) return AllFanProcessingTypes.SMOKING;
+        return null;
+    }
+
+    @Override
+    public void disableParticles(boolean disabled) {
+        vs_clockwork$disabledParticles = disabled;
     }
 
     @Override

--- a/common/src/main/java/org/valkyrienskies/clockwork/mixin/content/exhaust/MixinAirCurrent.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/mixin/content/exhaust/MixinAirCurrent.java
@@ -1,0 +1,33 @@
+package org.valkyrienskies.clockwork.mixin.content.exhaust;
+
+import com.simibubi.create.content.kinetics.fan.AirCurrent;
+import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
+import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.valkyrienskies.clockwork.mixinduck.MixinAirCurrentDuck;
+
+@Mixin(value = AirCurrent.class, remap = false)
+public class MixinAirCurrent implements MixinAirCurrentDuck {
+    @Unique
+    FanProcessingType vs_clockwork$ownProcessingType = null;
+
+    @ModifyVariable(method = "rebuild", at = @At("STORE"), name = "type")
+    private FanProcessingType applyOwnProcessingType(FanProcessingType type) {
+        return vs_clockwork$ownProcessingType;
+    }
+
+    @Override
+    public FanProcessingType getProcessingTypeFor(double temperature) {
+        if (temperature < 400) return null;
+        if (temperature < 700) return AllFanProcessingTypes.SMOKING;
+        return AllFanProcessingTypes.BLASTING;
+    }
+
+    @Override
+    public void setOwnProcessingType(FanProcessingType type) {
+        vs_clockwork$ownProcessingType = type;
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/clockwork/mixinduck/MixinAirCurrentDuck.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/mixinduck/MixinAirCurrentDuck.java
@@ -1,0 +1,9 @@
+package org.valkyrienskies.clockwork.mixinduck;
+
+import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
+
+public interface MixinAirCurrentDuck {
+    FanProcessingType getProcessingTypeFor(double temperature);
+
+    void setOwnProcessingType(FanProcessingType type);
+}

--- a/common/src/main/java/org/valkyrienskies/clockwork/mixinduck/MixinAirCurrentDuck.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/mixinduck/MixinAirCurrentDuck.java
@@ -5,5 +5,7 @@ import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
 public interface MixinAirCurrentDuck {
     FanProcessingType getProcessingTypeFor(double temperature);
 
+    void disableParticles(boolean disabled);
+
     void setOwnProcessingType(FanProcessingType type);
 }

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkConfig.kt
@@ -103,5 +103,20 @@ object ClockworkConfig {
 
         @ConfigEntry(description = "Air density at which the air compressor will start generating aether. Setting it to 0 or a negative number will disable helium generation")
         var airCompressorHeliumAirDensity = 0.3
+
+        @ConfigEntry(description = "Temperature for the gas heater to act like a passive heat source (campfires, dormant blaze burners). Default is 500K (baking oven)")
+        var heaterSmoulderingTemp = 500
+
+        @ConfigEntry(description = "Temperature for the gas heater to act like a heated blaze burner. Default is 1000K (ceramic firing)")
+        var heaterKindledTemp = 1000
+
+        @ConfigEntry(description = "Temperature for the gas heater to act like a superheated blaze burner. Default is 1500K (real metallurgy)")
+        var heaterSeethingTemp = 1500
+
+        @ConfigEntry(description = "Temperature for gas exhaust to trigger bulk smoking. Default is 500K (baking oven)")
+        var bulkSmokingTemp = 500
+
+        @ConfigEntry(description = "Temperature for gas exhaust to trigger bulk blasting. Default is 1000K (ceramic firing)")
+        var bulkBlastingTemp = 1000
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/exhaust/ExhaustBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/exhaust/ExhaustBlockEntity.kt
@@ -2,7 +2,6 @@ package org.valkyrienskies.clockwork.content.logistics.gas.exhaust
 
 import com.simibubi.create.content.kinetics.fan.AirCurrent
 import com.simibubi.create.content.kinetics.fan.IAirCurrentSource
-import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
 import com.simibubi.create.infrastructure.config.AllConfigs
 import net.minecraft.client.multiplayer.ClientLevel
@@ -27,7 +26,10 @@ class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockSt
     IAirCurrentSource {
 
     val MASS_PER_EXHAUST = 0.0005
-    val SPEED_FOR_PRESSURE = 256.0 / 2000.0
+    // Airflow speed parameters cannot be easily made configurable because air current code runs both on server and client
+    // so values need to somehow be synced.
+    val MAX_AIRFLOW_SPEED = 256F // like a maxed out encased fan with default max rpm cap
+    val PRESSURE_TO_SPEED = 256F / 2500 // outflow pressure in exhausts is very low compared to thrusters, may need tweaking later
 
     @JvmField
     var airCurrent: AirCurrent? = null
@@ -91,6 +93,7 @@ class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockSt
 
             val temp = network.getTemperatureAt(getDuctNodePosition())
             val duck = (airCurrent as? MixinAirCurrentDuck)
+            duck?.disableParticles(true)
             duck?.setOwnProcessingType(duck?.getProcessingTypeFor(temp))
 
             airCurrent?.rebuild();
@@ -111,8 +114,10 @@ class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockSt
     override fun getSpeed(): Float {
         val network = KelvinMod.getKelvinByPlatform() ?: return 0F
         val pressure = network.getPressureAt(getDuctNodePosition())
-        // Pressure in exhausts is low, 2 kPa corresponds to a rather intense input
-        return min(pressure * SPEED_FOR_PRESSURE, 256.0).toFloat()
+        return min(
+            (pressure * PRESSURE_TO_SPEED).toFloat(),
+            MAX_AIRFLOW_SPEED
+        )
     }
 
     // Copied from Create.

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/exhaust/ExhaustBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/exhaust/ExhaustBlockEntity.kt
@@ -1,13 +1,20 @@
 package org.valkyrienskies.clockwork.content.logistics.gas.exhaust
 
+import com.simibubi.create.content.kinetics.fan.AirCurrent
+import com.simibubi.create.content.kinetics.fan.IAirCurrentSource
+import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
+import com.simibubi.create.infrastructure.config.AllConfigs
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
 import net.minecraft.util.Mth
 import net.minecraft.util.RandomSource
+import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.properties.BlockStateProperties
+import org.valkyrienskies.clockwork.mixinduck.MixinAirCurrentDuck
 import org.valkyrienskies.clockwork.util.KNodeBlockEntity
 import org.valkyrienskies.clockwork.util.KelvinParticleHelper
 import org.valkyrienskies.kelvin.KelvinMod
@@ -16,9 +23,23 @@ import kotlin.math.floor
 import kotlin.math.min
 import kotlin.math.pow
 
-class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockState) : KNodeBlockEntity(type, pos, state) {
+class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockState) : KNodeBlockEntity(type, pos, state),
+    IAirCurrentSource {
 
     val MASS_PER_EXHAUST = 0.0005
+    val SPEED_FOR_PRESSURE = 256.0 / 2000.0
+
+    @JvmField
+    var airCurrent: AirCurrent? = null
+
+    var airCurrentUpdateCooldown: Int = 0
+    var entitySearchCooldown: Int = 0
+    var updateAirFlow: Boolean = false
+
+    init {
+        airCurrent = AirCurrent(this)
+        updateAirFlow = true
+    }
 
     override fun addBehaviours(behaviours: MutableList<BlockEntityBehaviour>?) {
         return
@@ -31,6 +52,7 @@ class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockSt
     override fun tick() {
         super.tick()
 
+        // Kelvin behavior
         val network = KelvinMod.getKelvinByPlatform() ?: return
         val gasses = network.getGasMassAt(getDuctNodePosition())
         val pressure = network.getPressureAt(getDuctNodePosition())
@@ -40,21 +62,81 @@ class ExhaustBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockSt
             val facing = level!!.getBlockState(blockPos).getValue(BlockStateProperties.FACING)
             val random = level!!.random
 
-
             for (i in 1..floor(gasses.values.sum()/MASS_PER_EXHAUST).toInt()) {
                 KelvinParticleHelper.spawnParticleWithRatio(level as ClientLevel, getDuctNodePosition(),
                     blockPos.toJOMLD().add(randomPos(0.3, random), randomPos(0.3, random), randomPos(0.3, random)),
                     facing.normal.toJOMLD().mul(Mth.clamp(0.0025 * pressure.pow(0.4), 0.1,5.0 )))
             }
-
-            return super.tick()
+        } else {
+            for ((gas, value) in gasses) {
+                network.removeGas(getDuctNodePosition(), gas, value)
+            }
         }
 
-        for ((gas,value) in gasses) {
-            network.removeGas(getDuctNodePosition(), gas, value)
+        updateAirCurrent()
+    }
+
+    fun updateAirCurrent() {
+        if (airCurrent == null) return
+
+        val network = KelvinMod.getKelvinByPlatform() ?: return
+
+        if (AllConfigs.server() != null && airCurrentUpdateCooldown-- <= 0) {
+            airCurrentUpdateCooldown = AllConfigs.server().kinetics.fanBlockCheckRate.get();
+            updateAirFlow = true;
         }
 
+        if (updateAirFlow) {
+            updateAirFlow = false;
 
+            val temp = network.getTemperatureAt(getDuctNodePosition())
+            val duck = (airCurrent as? MixinAirCurrentDuck)
+            duck?.setOwnProcessingType(duck?.getProcessingTypeFor(temp))
 
+            airCurrent?.rebuild();
+            sendData();
+        }
+
+        if (speed == 0.0F)
+            return;
+
+        if (entitySearchCooldown-- <= 0) {
+            entitySearchCooldown = 5;
+            airCurrent!!.findEntities();
+        }
+
+        airCurrent!!.tick();
+    }
+
+    override fun getSpeed(): Float {
+        val network = KelvinMod.getKelvinByPlatform() ?: return 0F
+        val pressure = network.getPressureAt(getDuctNodePosition())
+        // Pressure in exhausts is low, 2 kPa corresponds to a rather intense input
+        return min(pressure * SPEED_FOR_PRESSURE, 256.0).toFloat()
+    }
+
+    // Copied from Create.
+    override fun getAirCurrent(): AirCurrent? {
+        return airCurrent
+    }
+
+    override fun getAirCurrentWorld(): Level? {
+        return level
+    }
+
+    override fun getAirCurrentPos(): BlockPos? {
+        return worldPosition
+    }
+
+    override fun getAirflowOriginSide(): Direction? {
+        return blockState.getValue(BlockStateProperties.FACING)
+    }
+
+    override fun getAirFlowDirection(): Direction? {
+        return (if (speed == 0.0F) null else return blockState.getValue(BlockStateProperties.FACING))
+    }
+
+    override fun isSourceRemoved(): Boolean {
+        return remove
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/heater/GasHeaterBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/heater/GasHeaterBlockEntity.kt
@@ -8,6 +8,7 @@ import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
+import org.valkyrienskies.clockwork.ClockworkConfig
 import org.valkyrienskies.clockwork.ClockworkMod
 import org.valkyrienskies.clockwork.util.KNodeBlockEntity
 import org.valkyrienskies.kelvin.api.DuctNodePos
@@ -41,11 +42,10 @@ class GasHeaterBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: Block
         if (state.block !is GasHeaterBlock) return
 
         val heatLevel = when {
-            temp < 400 -> HeatLevel.NONE
-            temp < 750 -> HeatLevel.SMOULDERING
-            temp < 1250 -> HeatLevel.FADING
-            temp < 1500 -> HeatLevel.KINDLED
-            else -> HeatLevel.SEETHING
+            temp >= ClockworkConfig.SERVER.heaterSeethingTemp -> HeatLevel.SEETHING
+            temp >= ClockworkConfig.SERVER.heaterKindledTemp -> HeatLevel.KINDLED
+            temp >= ClockworkConfig.SERVER.heaterSmoulderingTemp -> HeatLevel.SMOULDERING
+            else -> HeatLevel.NONE
         }
 
         val energyInHeater = kelvin.getHeatEnergy(getDuctNodePosition())

--- a/common/src/main/resources/vs_clockwork-common.mixins.json
+++ b/common/src/main/resources/vs_clockwork-common.mixins.json
@@ -14,6 +14,7 @@
     "accessors.IMixinClockworkContraption",
     "accessors.IMixinPistonContraption",
     "content.blade.RepairItemRecipeMixin",
+    "content.exhaust.MixinAirCurrent",
     "content.gas.MixinBacktankUtil",
     "content.gas.MixinComposterBlock",
     "content.gas_engine.MixinSteamEngineBlock",


### PR DESCRIPTION
Exhausts now produce Create air currents, pushing away entities and enabling processing recipes like bulk washing or such. Not the complete set of features but doesn't break anything. Hot gas applies smoking/blasting effects, but that requires latest VS2 with [PR 1513](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/pull/1513) merged.


https://github.com/user-attachments/assets/33932554-e604-409f-87fd-960589b19ab1

I'm not a Kotlin guy so input is very welcome.