### PR TITLE
Redstone Resistor reverted mode

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/kinetics/resistor/RedstoneResistorBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/kinetics/resistor/RedstoneResistorBlockEntity.kt
@@ -1,18 +1,36 @@
 package org.valkyrienskies.clockwork.content.kinetics.resistor
 
+import com.mojang.blaze3d.vertex.PoseStack
 import com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation
+import com.simibubi.create.content.contraptions.DirectionalExtenderScrollOptionSlot
 import com.simibubi.create.content.kinetics.RotationPropagator
+import com.simibubi.create.content.kinetics.base.AbstractEncasedShaftBlock
+import com.simibubi.create.content.kinetics.motor.CreativeMotorBlock
 import com.simibubi.create.content.kinetics.transmission.SplitShaftBlockEntity
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
+import com.simibubi.create.foundation.blockEntity.behaviour.ValueBoxTransform
+import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.INamedIconOptions
+import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollOptionBehaviour
+import com.simibubi.create.foundation.gui.AllIcons
 import com.simibubi.create.foundation.utility.CreateLang
+import dev.engine_room.flywheel.lib.transform.TransformStack
 import net.createmod.catnip.data.Iterate
+import net.createmod.catnip.lang.Lang
+import net.createmod.catnip.math.AngleHelper
+import net.createmod.catnip.math.VecHelper
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.chat.Component
 import net.minecraft.world.level.Level
+import net.minecraft.world.level.LevelAccessor
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.phys.Vec3
 import net.minecraft.world.ticks.TickPriority
+import org.valkyrienskies.clockwork.ClockworkLang
+import org.valkyrienskies.clockwork.ClockworkMod
+import org.valkyrienskies.clockwork.content.contraptions.propeller.PropellerBearingBlockEntity.RotationDirection
 import org.valkyrienskies.clockwork.util.ClockworkConstants
 import kotlin.math.abs
 
@@ -20,6 +38,7 @@ open class RedstoneResistorBlockEntity(type: BlockEntityType<*>?, pos: BlockPos,
     SplitShaftBlockEntity(type, pos, state), IHaveGoggleInformation {
     var state = 0
     var lastChange = 0
+    lateinit var resistDirection: ScrollOptionBehaviour<ResistDirection>
     override fun tick() {
         super.tick()
         lastChange = state
@@ -60,11 +79,71 @@ open class RedstoneResistorBlockEntity(type: BlockEntityType<*>?, pos: BlockPos,
     override fun getRotationSpeedModifier(face: Direction): Float {
         if (hasSource()) {
             if (face != sourceFacing) {
-                val i = abs(state - 15) / 15f;
+                val i = if (resistDirection.get() == ResistDirection.MAX_TO_NONE) {
+                    abs(state - 15) / 15f
+                } else {
+                    abs(state) / 15f
+                }
                 return i
             }
         }
         return 1f
+    }
+
+    //add behavior for resistor direction
+    override fun addBehaviours(behaviours: MutableList<BlockEntityBehaviour?>) {
+        super.addBehaviours(behaviours)
+        resistDirection = ScrollOptionBehaviour(
+            ResistDirection::class.java,
+            ClockworkLang.translateDirect("contraptions.resistor.resist_direction"), this,
+            ResistorValueBox()
+        )
+        behaviours.add(resistDirection)
+    }
+
+    //resistor direction enum
+    enum class ResistDirection(private val icon: AllIcons) : INamedIconOptions {
+        MAX_TO_NONE(AllIcons.I_REFRESH),
+        NONE_TO_MAX(AllIcons.I_ROTATE_CCW); //don't know what else to put, "0 RPM to 256 RPM" is pretty long and not even accurate most the time.
+
+        private val translationKey: String = "resistor.resist_direction." + Lang.asId(name)
+
+        override fun getIcon(): AllIcons {
+            return icon
+        }
+
+        override fun getTranslationKey(): String {
+            return translationKey
+        }
+    }
+
+    //value box class for scroll behavior
+    class ResistorValueBox : ValueBoxTransform.Sided() {
+        override fun getSouthLocation(): Vec3? {
+            return VecHelper.voxelSpace(8.0, 8.0, 16.0)
+        }
+        override fun rotate(level: LevelAccessor?, pos: BlockPos?, state: BlockState, ms: PoseStack?) {
+            super.rotate(level, pos, state, ms)
+            val axis = state.getValue(AbstractEncasedShaftBlock.AXIS)
+
+            if (axis === Direction.Axis.Y) return
+            if (side != Direction.UP) return //default rotation so ignore/return
+
+            val horizontalAngle = when (axis) {
+                Direction.Axis.X -> 90f
+                Direction.Axis.Z -> 0f
+                else -> return
+            }
+
+            TransformStack.of(ms)
+                .rotateZDegrees(-horizontalAngle + 180f)
+        }
+
+        override fun isSideActive(state: BlockState, direction: Direction): Boolean {
+            val axis = state.getValue(AbstractEncasedShaftBlock.AXIS)
+            return direction.getAxis() !== axis
+        }
+
     }
 
     override fun addToGoggleTooltip(tooltip: MutableList<Component>, isPlayerSneaking: Boolean): Boolean {

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/kinetics/resistor/RedstoneResistorBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/kinetics/resistor/RedstoneResistorBlockEntity.kt
@@ -33,6 +33,7 @@ import org.valkyrienskies.clockwork.ClockworkMod
 import org.valkyrienskies.clockwork.content.contraptions.propeller.PropellerBearingBlockEntity.RotationDirection
 import org.valkyrienskies.clockwork.util.ClockworkConstants
 import kotlin.math.abs
+import kotlin.math.round
 
 open class RedstoneResistorBlockEntity(type: BlockEntityType<*>?, pos: BlockPos, state: BlockState) :
     SplitShaftBlockEntity(type, pos, state), IHaveGoggleInformation {
@@ -79,12 +80,13 @@ open class RedstoneResistorBlockEntity(type: BlockEntityType<*>?, pos: BlockPos,
     override fun getRotationSpeedModifier(face: Direction): Float {
         if (hasSource()) {
             if (face != sourceFacing) {
-                val i = if (resistDirection.get() == ResistDirection.MAX_TO_NONE) {
-                    abs(state - 15) / 15f
+                var i = if (resistDirection.get() == ResistDirection.MAX_TO_NONE) {
+                    abs(state - 15) / 15.0
                 } else {
-                    abs(state) / 15f
+                    abs(state) / 15.0
                 }
-                return i
+                i = round(i*10)/10
+                return i.toFloat()
             }
         }
         return 1f

--- a/common/src/main/resources/assets/vs_clockwork/lang/en_us.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/en_us.json
@@ -135,10 +135,13 @@
   "vs_clockwork.logistics.filter.click_to_set": "Click with an item to set.",
 
   "vs_clockwork.contraptions.propeller.rotation_direction": "Rotation Direction",
+  "vs_clockwork.contraptions.resistor.resist_direction": "Resistor Resist Direction",
   "contraptions.propeller.controller_wrong_way": "Blade Controller facing wrong way",
   "contraptions.propeller.not_prop": "Not a propeller",
   "propeller.rotation_direction.normal": "Normal",
   "propeller.rotation_direction.inverted": "Reversed",
+  "resistor.resist_direction.none_to_max": "None To Max",
+  "resistor.resist_direction.max_to_none": "Max To None",
 
   "vs_clockwork.gas_heater.heater_info": "    Heater Info",
   "vs_clockwork.gas_heater.heat_level": "Heat Level: %s",


### PR DESCRIPTION
Redstone resistor with the ability to revert
Max to none, none to max (so from 0RPM to whatever RPM that its getting)

side note: the "max to none" and "none to max" names could be changed, since its sort of unclear what it means, but i did not know what else to put, also the resistor model is unchanged, but should probably be changed as the Scroll Behavior is floating on the side of the block