### PR TITLE
Fix Create-like configs

### DIFF
--- a/common/src/main/java/org/valkyrienskies/clockwork/mixin/MixinBlockStressValues.java
+++ b/common/src/main/java/org/valkyrienskies/clockwork/mixin/MixinBlockStressValues.java
@@ -1,0 +1,33 @@
+package org.valkyrienskies.clockwork.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.simibubi.create.api.stress.BlockStressValues;
+import net.minecraft.world.level.block.Block;
+import org.spongepowered.asm.mixin.Mixin;
+import org.valkyrienskies.clockwork.ClockworkStress;
+
+import java.util.function.DoubleSupplier;
+
+@Mixin(BlockStressValues.class)
+public class MixinBlockStressValues {
+    @WrapMethod(method = "getImpact")
+    private static double injectCWImpact(Block block, Operation<Double> original) {
+        double base = original.call(block);
+        if (base == 0) {
+            DoubleSupplier sup = ClockworkStress.Companion.getImpact(block);
+            if (sup != null) return sup.getAsDouble();
+        }
+        return base;
+    }
+
+    @WrapMethod(method = "getCapacity")
+    private static double injectCWCapacity(Block block, Operation<Double> original) {
+        double base = original.call(block);
+        if (base == 0) {
+            DoubleSupplier sup = ClockworkStress.Companion.getCapacity(block);
+            if (sup != null) return sup.getAsDouble();
+        }
+        return base;
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkStress.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkStress.kt
@@ -82,7 +82,7 @@ class ClockworkStress : ConfigBase() {
         fun <B : Block, P> setImpact(value: Double): NonNullUnaryOperator<BlockBuilder<B, P>> {
             return NonNullUnaryOperator { builder: BlockBuilder<B, P> ->
                 assertFromClockwork(builder)
-                val id = Create.asResource(builder.getName())
+                val id = ClockworkMod.asResource(builder.getName())
                 DEFAULT_IMPACTS.put(id, value)
                 builder
             }
@@ -91,10 +91,22 @@ class ClockworkStress : ConfigBase() {
         fun <B : Block, P> setCapacity(value: Double): NonNullUnaryOperator<BlockBuilder<B, P>> {
             return NonNullUnaryOperator { builder: BlockBuilder<B, P> ->
                 assertFromClockwork(builder)
-                val id = Create.asResource(builder.getName())
+                val id = ClockworkMod.asResource(builder.getName())
                 DEFAULT_CAPACITIES.put(id, value)
                 builder
             }
+        }
+
+        fun getImpact(block: Block): DoubleSupplier? {
+            val id = CatnipServices.REGISTRIES.getKeyOrThrow(block)
+            val value = DEFAULT_IMPACTS[id]
+            return if (value == null) null else DoubleSupplier { value }
+        }
+
+        fun getCapacity(block: Block): DoubleSupplier? {
+            val id = CatnipServices.REGISTRIES.getKeyOrThrow(block)
+            val value = DEFAULT_CAPACITIES[id]
+            return if (value == null) null else DoubleSupplier { value }
         }
 
         private fun assertFromClockwork(builder: BlockBuilder<*, *>) {

--- a/common/src/main/resources/vs_clockwork-common.mixins.json
+++ b/common/src/main/resources/vs_clockwork-common.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "MixinAbstractContraptionEntity",
     "MixinBlockStateInfoProvider",
+    "MixinBlockStressValues",
     "MixinEntity",
     "MixinLivingEntity",
     "MixinPlayer",


### PR DESCRIPTION
This is not made to be merged.

Clockwork seemingly used to have a config system similar to what Create uses but is now commented out. There's a problem, it is actually very much necessary to have one because otherwise stress, capacity and etc are NOT ACTUALLY USED by Create! This is evident from goggles not showing kinetic stats of blocks like compressors but it is not just visual, it actually does not take any stress.

The mixins are, again, not to be merged, they provide a way to see how it is SUPPOSED to work once proper config is (re)implemented.