### PR TITLE
Fix gas nozzle not storing pointer value when rejoining

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/pockets/nozzle/GasNozzleBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/logistics/gas/pockets/nozzle/GasNozzleBlockEntity.kt
@@ -73,7 +73,7 @@ class GasNozzleBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: Block
     var soundInstance: GasNozzleSoundInstance? = null
 
     override fun write(tag: CompoundTag, clientPacket: Boolean) {
-
+        tag.putDouble("pointer_value", pointer.value.toDouble())
         tag.putDouble("pointer_target",pointer.chaseTarget.toDouble())
         tag.putDouble("pointer_speed",pointerSpeed)
         tag.putBoolean("has_pocket",hasPocket)
@@ -93,6 +93,7 @@ class GasNozzleBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: Block
         balloonVolume = tag.getDouble("balloon_volume")
         currentIdealOutput = tag.getInt("leaks").toDouble()
 
+        pointer.startWithValue(tag.getDouble("pointer_value"))
         pointer.chase(target, pointerSpeed, LerpedFloat.Chaser.LINEAR)
     }
 


### PR DESCRIPTION
Fixes #181 
**Note:** Nozzles on pre-existing worlds will have their pointers reset to 0.0 (fully closed).