### PR TITLE
Add flap bearing max size to config

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/ClockworkConfig.kt
@@ -168,5 +168,8 @@ object ClockworkConfig {
 
         @ConfigEntry(description = "The density mult of wanderlite ore in meteors", min = 0.0)
         val meteor_density = 0.0
+
+        @ConfigEntry(description = "Maximum size of an assembled flap bearing", min = 0.0, max = Int.MAX_VALUE.toDouble())
+        var flapBearingMaxSize = 16
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/flap/FlapBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/flap/FlapBearingBlockEntity.kt
@@ -19,11 +19,12 @@ import net.minecraft.nbt.CompoundTag
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.properties.BlockStateProperties
+import org.valkyrienskies.clockwork.ClockworkConfig
 import org.valkyrienskies.clockwork.ClockworkMod
 import org.valkyrienskies.clockwork.content.contraptions.flap.contraption.FlapContraption
 import org.valkyrienskies.core.impl.shadow.re
 
-open class FlapBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos, state: BlockState, val maxSize: Long = 16) :
+open class FlapBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos, state: BlockState, val maxSize: Long = ClockworkConfig.SERVER.flapBearingMaxSize.toLong()) :
     KineticBlockEntity(type, pos, state), IBearingBlockEntity, IDisplayAssemblyExceptions {
 
     var isRunning = false
@@ -136,7 +137,7 @@ open class FlapBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos, stat
         if (contraption == null) return
         if (contraption.blocks.isEmpty()) return
         if (contraption.blocks.size > maxSize && maxSize != -1L) {
-            lastException = AssemblyException.structureTooLarge()
+            lastException = AssemblyException("structureTooLarge", maxSize)
             return sendData()
         }
         val anchor = worldPosition.relative(direction)


### PR DESCRIPTION
Closes #218 
This adds a config for the max size of an assembled flap bearing.
This also changes the AssemblyException to include the flap bearing's max size.

I am using an Int in the config because for some reason when using a Long, it resets the config? I am not completely sure since I am quite new to reading the codebase, would be happy for some feedback :).