### PR TITLE
1.20.1/fix phys bearings

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -130,6 +130,11 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     private var lastAligningState = false
     private var missingSubShipTicks = 0
 
+    private var followAngleStalled = false
+    private var followAngleStallTicks = 0
+    private var followAngleStallDirSign = 0
+    private var lastActualAngleRadForStall: Double? = null
+
     // Phys-thread reads these; game-thread writes them.
     @Volatile private var servoMode: LockedMode = LockedMode.UNLOCKED
     @Volatile private var lockedHoldAngleRad: Double? = null
@@ -281,7 +286,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         joint = baseJoint
         servoMode = mode
         // Sign matches tick() targetAngle integration and BearingController's ideal omega convention.
-        followOmegaFeedForwardRadSec = if (!aligning && mode == LockedMode.FOLLOW_ANGLE) -getRealisticAngularSpeed().toDouble() else 0.0
+        followOmegaFeedForwardRadSec =
+            if (!aligning && mode == LockedMode.FOLLOW_ANGLE && !followAngleStalled) -getRealisticAngularSpeed().toDouble() else 0.0
 
         controllerUpdateData = PhysBearingUpdateData(
             Math.toRadians(targetAngle.toDouble()),
@@ -302,6 +308,114 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         // Returns error in (-pi, pi].
         val d = target - current
         return atan2(sin(d), cos(d))
+    }
+
+    private fun normalizeAngleDeg0To720(angleDeg: Double): Float {
+        val period = 360.0 * 2.0
+        var wrapped = angleDeg % period
+        if (wrapped < 0.0) wrapped += period
+        return wrapped.toFloat()
+    }
+
+    private fun clearFollowAngleStallState() {
+        followAngleStalled = false
+        followAngleStallTicks = 0
+        followAngleStallDirSign = 0
+        lastActualAngleRadForStall = null
+    }
+
+    private fun updateFollowAngleStallState(cmdSpeedDegPerTick: Float) {
+        val level = level as? ServerLevel ?: return
+        val mode = movementMode?.get() ?: LockedMode.UNLOCKED
+        if (!isRunning || aligning || mode != LockedMode.FOLLOW_ANGLE || shiptraptionID == NO_SHIPTRAPTION_ID) {
+            if (followAngleStalled || followAngleStallTicks != 0 || lastActualAngleRadForStall != null) {
+                clearFollowAngleStallState()
+                updateDrive()
+                sendData()
+            }
+            return
+        }
+
+        val cmdMag = abs(cmdSpeedDegPerTick)
+        val cmdSign = cmdSpeedDegPerTick.sign.toInt()
+
+        // If the player stops commanding rotation, clear stall so the next input can move again.
+        if (cmdMag < FOLLOW_STALL_MIN_CMD_DEG_PER_TICK || cmdSign == 0) {
+            if (followAngleStalled) {
+                clearFollowAngleStallState()
+                if (DEBUG_SERVO) {
+                    ClockworkMod.LOGGER.info("[PhysBearing] follow stall cleared (cmd=0)")
+                }
+                updateDrive()
+                sendData()
+            } else {
+                followAngleStallTicks = 0
+                followAngleStallDirSign = 0
+                lastActualAngleRadForStall = null
+            }
+            return
+        }
+
+        // If stalled, only clear when the player reverses direction.
+        if (followAngleStalled) {
+            if (cmdSign != followAngleStallDirSign) {
+                clearFollowAngleStallState()
+                if (DEBUG_SERVO) {
+                    ClockworkMod.LOGGER.info("[PhysBearing] follow stall cleared (dir change)")
+                }
+                updateDrive()
+                sendData()
+            }
+            return
+        }
+
+        val actualRad = getActualAngle() ?: run {
+            // Can't observe motion yet; don't accumulate stall ticks.
+            followAngleStallTicks = 0
+            lastActualAngleRadForStall = null
+            return
+        }
+
+        val lastRad = lastActualAngleRadForStall
+        lastActualAngleRadForStall = actualRad
+
+        // Direction changed => restart stall detection.
+        if (followAngleStallDirSign != 0 && cmdSign != followAngleStallDirSign) {
+            followAngleStallTicks = 0
+        }
+        followAngleStallDirSign = cmdSign
+
+        if (lastRad == null) return
+
+        val actualDeltaRad = abs(shortestAngleErrorRad(actualRad, lastRad))
+        val cmdDeltaRad = cmdMag.toDouble() * (Math.PI / 180.0) // deg/tick -> rad/tick
+        val epsRad = max(FOLLOW_STALL_EPS_RAD_BASE, cmdDeltaRad * FOLLOW_STALL_EPS_FRACTION)
+
+        if (actualDeltaRad < epsRad) {
+            followAngleStallTicks++
+        } else {
+            followAngleStallTicks = 0
+        }
+
+        if (followAngleStallTicks < FOLLOW_STALL_TICKS) return
+
+        // Stalled: stop advancing the expected angle and remove omega feed-forward so we stop pushing into collisions.
+        followAngleStalled = true
+        followAngleStallTicks = 0
+        followAngleStallDirSign = cmdSign
+        targetAngle = normalizeAngleDeg0To720(Math.toDegrees(actualRad))
+
+        if (DEBUG_SERVO) {
+            ClockworkMod.LOGGER.info(
+                "[PhysBearing] follow stalled (cmdDegTick={}, actualDeltaRad={}, epsRad={})",
+                cmdSpeedDegPerTick,
+                actualDeltaRad,
+                epsRad
+            )
+        }
+
+        updateDrive()
+        sendData()
     }
 
     private fun getAngularInertia(physShip: PhysShip, localPos: Vector3dc, axisGlobal: Vector3dc): Double {
@@ -443,6 +557,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         tag.putVector3d("bearingPos", bearingPos)
         tag.putVector3d("bearingAxis", bearingAxis)
         tag.putBoolean("aligning", aligning)
+        if (clientPacket) {
+            tag.putBoolean("followAngleStalled", followAngleStalled)
+        }
 
         val mapper = VSJacksonUtil.dtoMapper
         // Avoid saving a potentially large/non-zero drive velocity from mid-servo movement.
@@ -537,6 +654,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         bearingPos = tag.getVector3d("bearingPos")!!
         bearingAxis = tag.getVector3d("bearingAxis")!!
         aligning = tag.getBoolean("aligning")
+        if (clientPacket && tag.contains("followAngleStalled")) {
+            followAngleStalled = tag.getBoolean("followAngleStalled")
+        }
 
         val mapper = VSJacksonUtil.dtoMapper
 
@@ -604,6 +724,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         get() {
             val mode = movementMode?.get() ?: LockedMode.UNLOCKED
             if (aligning || mode == LockedMode.LOCKED) return 0f
+            if (mode == LockedMode.FOLLOW_ANGLE && followAngleStalled) return 0f
             var speed = convertToAngular(getSpeed())
             if (getSpeed() == 0f) speed = 0f
             if (level!!.isClientSide) {
@@ -908,6 +1029,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         lastAngle = 0f
         curAngle = 0f
+
+        clearFollowAngleStallState()
     }
 
     private fun tryAssembleNextTick() {
@@ -1045,10 +1168,20 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         tickAnimationLogic()
         if (!isRunning) return
         val mode = movementMode?.get() ?: LockedMode.UNLOCKED
+        if (mode != LockedMode.FOLLOW_ANGLE && (followAngleStalled || followAngleStallTicks != 0 || lastActualAngleRadForStall != null)) {
+            // Stall state is only meaningful for FOLLOW_ANGLE.
+            clearFollowAngleStallState()
+        }
         if (shiptraptionID == NO_SHIPTRAPTION_ID) {
             targetAngle = 0f
         } else if (joint != null && jointID != -1 && !aligning && mode != LockedMode.LOCKED) {
             val angularSpeed = -getActualAngularSpeed()
+            if (!level!!.isClientSide && mode == LockedMode.FOLLOW_ANGLE) {
+                updateFollowAngleStallState(angularSpeed)
+            }
+            if (mode == LockedMode.FOLLOW_ANGLE && followAngleStalled) {
+                // Don't advance the expected angle while stalled.
+            } else {
             var diff = 0.0f
 
             if (sequencedAngleLimit >= 0.0f) {
@@ -1078,6 +1211,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
                 newAngle >= 360f * 2 -> newAngle - 360f * 2
                 newAngle < 0f -> newAngle + 360f * 2
                 else -> newAngle
+            }
             }
         }
         //needs to be after targetAngle change
@@ -1239,7 +1373,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         // - Kd is chosen for a fixed damping ratio to minimize sway/overshoot.
         // - "Strength" caps both max torque and max angular acceleration.
         // Temporary: boost slider magnitudes for testing (e.g., UI 100 behaves like 1000 if set to 10.0).
-        private const val SERVO_TEST_SCALE = 1.0
+        private const val SERVO_TEST_SCALE = 2.0
         private const val SERVO_DAMPING_RATIO = 1.25
         private const val SERVO_WN_MIN = 4.0
         private const val SERVO_WN_MAX = 64.0
@@ -1249,6 +1383,13 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_FORCE_TORQUE_MAX = 1.0e10
 
         private const val MISSING_SUBSHIP_GRACE_TICKS = 20
+
+        // FOLLOW_ANGLE stall detection: if we keep commanding rotation but the actual angle isn't moving,
+        // stop advancing the expected angle so we don't push into collisions indefinitely.
+        private const val FOLLOW_STALL_MIN_CMD_DEG_PER_TICK = 0.05f
+        private const val FOLLOW_STALL_TICKS = 5
+        private const val FOLLOW_STALL_EPS_RAD_BASE = 1.0e-4
+        private const val FOLLOW_STALL_EPS_FRACTION = 0.005
 
         // Servo tuning (acceleration-space PD):
         //   alpha_cmd = Kp * angle_error + Kd * (omega_target - omega_actual)

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -162,6 +162,10 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     // Phys-thread filtered feedback used to avoid exciting solver jitter near hold.
     @Volatile private var servoOmegaActualFilteredRadSec: Double = 0.0
     @Volatile private var servoAlphaCmdFilteredRadSec2: Double = 0.0
+    // Compensates unmodeled downstream inertia (e.g., bearing chains) by matching commanded vs observed response.
+    @Volatile private var servoApparentInertiaScale: Double = 1.0
+    @Volatile private var servoPrevOmegaActualForApparentInertiaScaleRadSec: Double = Double.NaN
+    @Volatile private var servoPrevAppliedHingeTorqueMag: Double = 0.0
 
     private var controllerCreationData: PhysBearingData? = null
     private var controllerUpdateData: PhysBearingUpdateData? = null
@@ -278,6 +282,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         mainShip: PhysShip?,
         hingeOmegaRadSec: Double
     ): VSRevoluteJoint {
+        val chainedDynamic = !subShip.isStatic && mainShip != null && !mainShip.isStatic
+        val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
         if (SERVO_REANCHOR_PERIOD_TICKS <= 0) return joint
         physServoTickCounter++
         if (physServoTickCounter % SERVO_REANCHOR_PERIOD_TICKS != 0) return joint
@@ -295,13 +301,25 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val relAnchorVel = mainAnchorVel.sub(subAnchorVel, Vector3d())
         val relAnchorSpeed = relAnchorVel.length()
         val absHingeOmega = abs(hingeOmegaRadSec)
+        val maxHingeOmegaForReanchor =
+            if (chainedDynamic) {
+                lerpClamped(SERVO_REANCHOR_CHAIN_MAX_HINGE_OMEGA_RAD_SEC, SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC, chainBlend)
+            } else {
+                SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC
+            }
+        val maxRelVelForReanchor =
+            if (chainedDynamic) {
+                lerpClamped(SERVO_REANCHOR_CHAIN_MAX_REL_VEL_MPS, SERVO_REANCHOR_MAX_REL_VEL_MPS, chainBlend)
+            } else {
+                SERVO_REANCHOR_MAX_REL_VEL_MPS
+            }
         if (!relAnchorSpeed.isFinite() || !absHingeOmega.isFinite()) return joint
-        if (absHingeOmega > SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC || relAnchorSpeed > SERVO_REANCHOR_MAX_REL_VEL_MPS) return joint
+        if (absHingeOmega > maxHingeOmegaForReanchor || relAnchorSpeed > maxRelVelForReanchor) return joint
 
         // As hinge/anchor motion rises, shrink reanchor corrections to avoid injecting impulses.
         val motionRatio = max(
-            absHingeOmega / max(SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC, 1.0e-6),
-            relAnchorSpeed / max(SERVO_REANCHOR_MAX_REL_VEL_MPS, 1.0e-6)
+            absHingeOmega / max(maxHingeOmegaForReanchor, 1.0e-6),
+            relAnchorSpeed / max(maxRelVelForReanchor, 1.0e-6)
         )
         val motionScale = (1.0 - motionRatio).coerceIn(0.0, 1.0)
         if (motionScale < SERVO_REANCHOR_MIN_MOTION_SCALE) return joint
@@ -312,7 +330,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         // Don't do large corrections in one go; that can introduce impulses. Nudge toward the desired anchor.
         val deltaWorld = anchor1World.sub(anchor0World, Vector3d())
-        val maxStepNow = SERVO_REANCHOR_MAX_STEP * motionScale
+        val stepScale = if (chainedDynamic) lerpClamped(SERVO_REANCHOR_CHAIN_STEP_SCALE, 1.0, chainBlend) else 1.0
+        val baseMaxStep = SERVO_REANCHOR_MAX_STEP * stepScale
+        val maxStepNow = baseMaxStep * motionScale
         if (maxStepNow < SERVO_REANCHOR_MIN_STEP) return joint
         val step = min(err, maxStepNow)
         val targetWorld = if (err > 0.0) {
@@ -430,6 +450,87 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     private fun clearServoFilterState() {
         servoOmegaActualFilteredRadSec = 0.0
         servoAlphaCmdFilteredRadSec2 = 0.0
+        servoApparentInertiaScale = 1.0
+        servoPrevOmegaActualForApparentInertiaScaleRadSec = Double.NaN
+        servoPrevAppliedHingeTorqueMag = 0.0
+    }
+
+    private fun servoStrength01(): Double {
+        return (servoStrengthSetting.toDouble() / SERVO_STRENGTH_MAX.toDouble()).coerceIn(0.0, 1.0)
+    }
+
+    private fun chainAuthorityBlend01(): Double {
+        // 0 = conservative chain attenuation, 1 = full authority from the strength slider.
+        return smoothStep(SERVO_CHAIN_AUTHORITY_BLEND_START, SERVO_CHAIN_AUTHORITY_BLEND_END, servoStrength01())
+    }
+
+    private fun apparentInertiaScaleMax(): Double {
+        return lerpClamped(
+            SERVO_APPARENT_INERTIA_MAX_SCALE_MIN_STRENGTH,
+            SERVO_APPARENT_INERTIA_MAX_SCALE_MAX_STRENGTH,
+            servoStrength01()
+        ).coerceAtLeast(1.0)
+    }
+
+    private fun stabilizerApparentInertiaScale(): Double {
+        val raw = servoApparentInertiaScale.coerceIn(1.0, apparentInertiaScaleMax())
+        val blended = 1.0 + (raw - 1.0) * SERVO_APPARENT_INERTIA_STABILIZER_SHARE
+        return blended.coerceIn(1.0, SERVO_APPARENT_INERTIA_STABILIZER_MAX_SCALE)
+    }
+
+    private fun updateApparentInertiaScale(
+        baseInertia: Double,
+        omegaActual: Double,
+        errorRad: Double,
+        omegaErr: Double
+    ): Double {
+        val maxScale = apparentInertiaScaleMax()
+        var scale = servoApparentInertiaScale.coerceIn(1.0, maxScale)
+        val dt = SERVO_PHYS_TICK_DT_SEC
+        val prevOmega = servoPrevOmegaActualForApparentInertiaScaleRadSec
+        val prevTorque = servoPrevAppliedHingeTorqueMag
+        val demandingMotion =
+            abs(errorRad) > SERVO_APPARENT_INERTIA_ACTIVE_ERROR_RAD ||
+                abs(omegaErr) > SERVO_APPARENT_INERTIA_ACTIVE_OMEGA_ERR_RAD_SEC
+
+        if (
+            demandingMotion &&
+            dt > 1.0e-6 &&
+            baseInertia.isFinite() &&
+            baseInertia > SERVO_APPARENT_INERTIA_MIN_BASE &&
+            prevOmega.isFinite() &&
+            prevTorque.isFinite() &&
+            abs(prevTorque) > SERVO_APPARENT_INERTIA_MIN_OBS_TORQUE
+        ) {
+            val alphaObserved = (omegaActual - prevOmega) / dt
+            if (alphaObserved.isFinite()) {
+                if (prevTorque * alphaObserved > 0.0) {
+                    // Keep denominator bounded so near-zero measured accel under heavy load drives authority up quickly.
+                    val alphaDenom = max(abs(alphaObserved), SERVO_APPARENT_INERTIA_ALPHA_FLOOR_RAD_SEC2)
+                    val targetScale = (abs(prevTorque) / (baseInertia * alphaDenom)).coerceIn(1.0, maxScale)
+                    val lpAlpha =
+                        if (targetScale > scale) SERVO_APPARENT_INERTIA_RISE_ALPHA else SERVO_APPARENT_INERTIA_FALL_ALPHA
+                    scale = lowPass(scale, targetScale, lpAlpha)
+                } else {
+                    // Opposing acceleration usually means external disturbances/joint coupling; do not chase aggressively.
+                    scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_OPPOSED_DECAY_ALPHA)
+                }
+            }
+        } else {
+            scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA)
+        }
+
+        if (
+            abs(errorRad) < SERVO_APPARENT_INERTIA_SETTLED_ERROR_RAD &&
+            abs(omegaActual) < SERVO_APPARENT_INERTIA_SETTLED_OMEGA_RAD_SEC
+        ) {
+            scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_SETTLED_DECAY_ALPHA)
+        }
+
+        val clamped = scale.coerceIn(1.0, maxScale)
+        servoApparentInertiaScale = clamped
+        servoPrevOmegaActualForApparentInertiaScaleRadSec = omegaActual
+        return clamped
     }
 
     private fun normalizeAngleDeg0To720(angleDeg: Double): Float {
@@ -570,6 +671,21 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         return 1.0 / (1.0 / left + 1.0 / right)
     }
 
+    private fun boostedCoupledEquivalent(
+        parallelValue: Double,
+        firstValue: Double,
+        secondValue: Double,
+        blend01: Double
+    ): Double {
+        if (!parallelValue.isFinite() || parallelValue <= 0.0) return parallelValue
+        val sumValue = firstValue + secondValue
+        if (!sumValue.isFinite() || sumValue <= 0.0) return parallelValue
+
+        // Blend reduced-inertia coupling toward a pseudo-rigid equivalent at high slider.
+        val cappedTarget = min(sumValue, parallelValue * SERVO_CHAIN_COUPLED_EQ_MAX_RATIO)
+        return lerpClamped(parallelValue, cappedTarget, blend01)
+    }
+
     private fun rejectAlongAxis(vec: Vector3dc, axisUnit: Vector3dc): Vector3d {
         return vec.sub(axisUnit.mul(axisUnit.dot(vec), Vector3d()), Vector3d())
     }
@@ -638,32 +754,67 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val relVel = mainAnchorVel.sub(subAnchorVel, Vector3d())
         val errorLen = anchorErrorRaw.length()
         val relVelLen = relVel.length()
-        if (errorLen < SERVO_SEAT_ERROR_DEADBAND_M && relVelLen < SERVO_SEAT_VEL_DEADBAND) return
+        val worldAnchored = mainShip == null || mainShip.isStatic
+        val chainedDynamic = mainShip != null && !mainShip.isStatic && !subShip.isStatic
+        val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
+        val seatErrorDeadband = if (chainedDynamic) {
+            lerpClamped(SERVO_SEAT_CHAIN_ERROR_DEADBAND_M, SERVO_SEAT_ERROR_DEADBAND_M, chainBlend)
+        } else {
+            SERVO_SEAT_ERROR_DEADBAND_M
+        }
+        val seatVelDeadband = if (chainedDynamic) {
+            lerpClamped(SERVO_SEAT_CHAIN_VEL_DEADBAND, SERVO_SEAT_VEL_DEADBAND, chainBlend)
+        } else {
+            SERVO_SEAT_VEL_DEADBAND
+        }
+        if (errorLen < seatErrorDeadband && relVelLen < seatVelDeadband) return
         val anchorError = if (errorLen > SERVO_SEAT_MAX_ERROR_M && errorLen > 1.0e-9) {
             anchorErrorRaw.mul(SERVO_SEAT_MAX_ERROR_M / errorLen, Vector3d())
         } else {
             anchorErrorRaw
         }
 
-        val effMass = when {
-            subDynamic && mainDynamic -> parallelOperator(subShip.mass, mainShip!!.mass)
+        val effMassBase = when {
+            subDynamic && mainDynamic -> {
+                val mainMass = mainShip!!.mass
+                val baseParallel = parallelOperator(subShip.mass, mainMass)
+                if (chainedDynamic) {
+                    boostedCoupledEquivalent(baseParallel, subShip.mass, mainMass, chainBlend)
+                } else {
+                    baseParallel
+                }
+            }
             subDynamic -> subShip.mass
             else -> mainShip!!.mass
         }
+        if (!effMassBase.isFinite() || effMassBase <= 0.0) return
+        val effMass = effMassBase * stabilizerApparentInertiaScale()
         if (!effMass.isFinite() || effMass <= 0.0) return
 
         val sliderScale = SERVO_SLIDER_TEST_SCALE.coerceAtLeast(0.0)
-        val worldAnchored = mainShip == null || mainShip.isStatic
-        val seatWn = servoSeatWn.coerceIn(0.0, SERVO_SEAT_WN_MAX * sliderScale)
+        val seatWnScale = if (chainedDynamic) lerpClamped(SERVO_SEAT_CHAIN_WN_SCALE, 1.0, chainBlend) else 1.0
+        val seatWn = (servoSeatWn.coerceIn(0.0, SERVO_SEAT_WN_MAX * sliderScale) * seatWnScale)
         val seatDamping = servoSeatDampingRatio.coerceIn(0.0, SERVO_SEAT_DAMPING_RATIO_MAX * sliderScale)
-        val seatKpScale = if (worldAnchored) SERVO_SEAT_WORLD_ANCHOR_KP_SCALE else 1.0
-        val seatKdScale = if (worldAnchored) SERVO_SEAT_WORLD_ANCHOR_KD_SCALE else 1.0
+        val seatKpScale = when {
+            worldAnchored -> SERVO_SEAT_WORLD_ANCHOR_KP_SCALE
+            chainedDynamic -> lerpClamped(SERVO_SEAT_CHAIN_KP_SCALE, 1.0, chainBlend)
+            else -> 1.0
+        }
+        val seatKdScale = when {
+            worldAnchored -> SERVO_SEAT_WORLD_ANCHOR_KD_SCALE
+            chainedDynamic -> lerpClamped(SERVO_SEAT_CHAIN_KD_SCALE, 1.0, chainBlend)
+            else -> 1.0
+        }
         val seatKp = seatWn * seatWn * seatKpScale
         val seatKd = 2.0 * seatDamping * seatWn * seatKdScale
 
         var seatAccCmd = anchorError.mul(seatKp, Vector3d()).add(relVel.mul(seatKd, Vector3d()))
         if (!seatAccCmd.isFiniteVec()) return
-        val maxSeatAccel = if (worldAnchored) SERVO_SEAT_MAX_ACCEL_WORLD_ANCHOR else SERVO_SEAT_MAX_ACCEL_HARD
+        val maxSeatAccel = when {
+            worldAnchored -> SERVO_SEAT_MAX_ACCEL_WORLD_ANCHOR
+            chainedDynamic -> lerpClamped(SERVO_SEAT_MAX_ACCEL_CHAIN, SERVO_SEAT_MAX_ACCEL_HARD, chainBlend)
+            else -> SERVO_SEAT_MAX_ACCEL_HARD
+        }
         val seatAccLen = seatAccCmd.length()
         if (seatAccLen > maxSeatAccel && seatAccLen > 1.0e-9) {
             seatAccCmd.mul(maxSeatAccel / seatAccLen)
@@ -712,22 +863,53 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
         val offAxisOmega = rejectAlongAxis(relOmegaWorld, axisWorldUnit)
         val offAxisOmegaLen = offAxisOmega.length()
-        if ((!offAxisOmegaLen.isFinite() || offAxisOmegaLen < SERVO_TILT_OMEGA_DEADBAND) && swingErrorWorld.length() < 1.0e-6) return
+        val worldAnchored = mainShip == null || mainShip.isStatic
+        val chainedDynamic = mainShip != null && !mainShip.isStatic && !subShip.isStatic
+        val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
+        val tiltOmegaDeadband = if (chainedDynamic) {
+            lerpClamped(SERVO_TILT_CHAIN_OMEGA_DEADBAND, SERVO_TILT_OMEGA_DEADBAND, chainBlend)
+        } else {
+            SERVO_TILT_OMEGA_DEADBAND
+        }
+        if ((!offAxisOmegaLen.isFinite() || offAxisOmegaLen < tiltOmegaDeadband) && swingErrorWorld.length() < 1.0e-6) return
 
         val sliderScale = SERVO_SLIDER_TEST_SCALE.coerceAtLeast(0.0)
-        val worldAnchored = mainShip == null || mainShip.isStatic
-        val tiltWnScale = if (worldAnchored) SERVO_TILT_WORLD_ANCHOR_WN_SCALE else 1.0
+        val tiltWnScale = when {
+            worldAnchored -> SERVO_TILT_WORLD_ANCHOR_WN_SCALE
+            chainedDynamic -> lerpClamped(SERVO_TILT_CHAIN_WN_SCALE, 1.0, chainBlend)
+            else -> 1.0
+        }
         val tiltWn = (servoTiltWn.coerceIn(0.0, SERVO_TILT_WN_MAX * sliderScale) * tiltWnScale)
         val tiltDamping = servoTiltDampingRatio.coerceIn(0.0, SERVO_TILT_DAMPING_RATIO_MAX * sliderScale)
-        val tiltKp = tiltWn * tiltWn
-        val tiltKd = 2.0 * tiltDamping * tiltWn
+        val tiltKpScale = if (chainedDynamic) lerpClamped(SERVO_TILT_CHAIN_KP_SCALE, 1.0, chainBlend) else 1.0
+        val tiltKdScale = when {
+            worldAnchored -> SERVO_TILT_WORLD_ANCHOR_KD_SCALE
+            chainedDynamic -> lerpClamped(SERVO_TILT_CHAIN_KD_SCALE, 1.0, chainBlend)
+            else -> 1.0
+        }
+        val tiltKp = tiltWn * tiltWn * tiltKpScale
+        val tiltKd = 2.0 * tiltDamping * tiltWn * tiltKdScale
+        val dampOnlyErrorRad = if (chainedDynamic) {
+            lerpClamped(SERVO_TILT_CHAIN_DAMP_ONLY_ERROR_RAD, SERVO_TILT_DAMP_ONLY_ERROR_RAD, chainBlend)
+        } else {
+            SERVO_TILT_DAMP_ONLY_ERROR_RAD
+        }
+        val fullStiffnessErrorRad = if (chainedDynamic) {
+            lerpClamped(SERVO_TILT_CHAIN_FULL_STIFFNESS_ERROR_RAD, SERVO_TILT_FULL_STIFFNESS_ERROR_RAD, chainBlend)
+        } else {
+            SERVO_TILT_FULL_STIFFNESS_ERROR_RAD
+        }
         val stiffnessBlend =
-            smoothStep(SERVO_TILT_DAMP_ONLY_ERROR_RAD, SERVO_TILT_FULL_STIFFNESS_ERROR_RAD, swingErrorWorld.length())
+            smoothStep(dampOnlyErrorRad, fullStiffnessErrorRad, swingErrorWorld.length())
 
         var tiltAlphaCmd = swingErrorWorld.mul(-tiltKp * stiffnessBlend, Vector3d()).add(offAxisOmega.mul(-tiltKd, Vector3d()))
         if (!tiltAlphaCmd.isFiniteVec()) return
         var tiltAlphaLen = tiltAlphaCmd.length()
-        val maxTiltAlpha = if (worldAnchored) SERVO_TILT_MAX_ALPHA_WORLD_ANCHOR else SERVO_TILT_MAX_ALPHA_HARD
+        val maxTiltAlpha = when {
+            worldAnchored -> SERVO_TILT_MAX_ALPHA_WORLD_ANCHOR
+            chainedDynamic -> lerpClamped(SERVO_TILT_MAX_ALPHA_CHAIN, SERVO_TILT_MAX_ALPHA_HARD, chainBlend)
+            else -> SERVO_TILT_MAX_ALPHA_HARD
+        }
         if (tiltAlphaLen > maxTiltAlpha && tiltAlphaLen > 1.0e-9) {
             tiltAlphaCmd.mul(maxTiltAlpha / tiltAlphaLen)
             tiltAlphaLen = tiltAlphaCmd.length()
@@ -741,15 +923,22 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             return
         }
 
-        val effInertia = when {
+        val effInertiaBase = when {
             subDynamic && mainDynamic -> {
                 val subInertia = getAngularInertia(subShip, joint.pose0.pos, tiltAxis)
                 val mainInertia = getAngularInertia(mainShip!!, joint.pose1.pos, tiltAxis)
-                parallelOperator(subInertia, mainInertia)
+                val baseParallel = parallelOperator(subInertia, mainInertia)
+                if (chainedDynamic) {
+                    boostedCoupledEquivalent(baseParallel, subInertia, mainInertia, chainBlend)
+                } else {
+                    baseParallel
+                }
             }
             subDynamic -> getAngularInertia(subShip, joint.pose0.pos, tiltAxis)
             else -> getAngularInertia(mainShip!!, joint.pose1.pos, tiltAxis)
         }
+        if (!effInertiaBase.isFinite() || effInertiaBase <= 0.0) return
+        val effInertia = effInertiaBase * stabilizerApparentInertiaScale()
         if (!effInertia.isFinite() || effInertia <= 0.0) return
 
         var tiltTorque = tiltAlphaCmd.mul(effInertia, Vector3d())
@@ -759,10 +948,10 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         } else {
             SERVO_TILT_TORQUE_MIN * sliderScale
         }
-        val maxTiltTorqueByAlpha = effInertia * if (worldAnchored) {
-            SERVO_TILT_MAX_ALPHA_EQUIV_WORLD_ANCHOR
-        } else {
-            SERVO_TILT_MAX_ALPHA_EQUIV
+        val maxTiltTorqueByAlpha = effInertia * when {
+            worldAnchored -> SERVO_TILT_MAX_ALPHA_EQUIV_WORLD_ANCHOR
+            chainedDynamic -> lerpClamped(SERVO_TILT_MAX_ALPHA_EQUIV_CHAIN, SERVO_TILT_MAX_ALPHA_EQUIV, chainBlend)
+            else -> SERVO_TILT_MAX_ALPHA_EQUIV
         }
         val clampedMaxTiltTorque = min(maxTiltTorque, maxTiltTorqueByAlpha)
         if (!clampedMaxTiltTorque.isFinite() || clampedMaxTiltTorque <= 0.0) return
@@ -905,12 +1094,10 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             (physLevel as? VsiPhysLevel)?.updateJoint(jointId, updated)
         }
 
-        // Strong translational lock at the anchors, plus off-axis angular swing lock.
-        applyAnchorSeatStabilizer(updated, subShip, mainShip)
-        applyOffAxisAngularStabilizer(updated, subShip, mainShip, axisWorld, relOmegaWorld)
-
         // Torque servo (works even when revolute drive velocity is not honored).
-        val torqueMassMultiplier: Double = run {
+        val chainedDynamic = !subShip.isStatic && mainShip != null && !mainShip.isStatic
+        val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
+        val torqueMassMultiplierBase: Double = run {
             val canSub = !subShip.isStatic
             val canMain = mainShip != null && !mainShip.isStatic
             if (!canSub && !canMain) return
@@ -919,12 +1106,35 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             val mainInertia = if (canMain) getAngularInertia(mainShip!!, updated.pose1.pos, axisWorld) else 0.0
 
             when {
-                canSub && canMain -> parallelOperator(subInertia, mainInertia)
+                canSub && canMain -> {
+                    val baseParallel = parallelOperator(subInertia, mainInertia)
+                    if (chainedDynamic) {
+                        boostedCoupledEquivalent(baseParallel, subInertia, mainInertia, chainBlend)
+                    } else {
+                        baseParallel
+                    }
+                }
                 canSub -> subInertia
                 else -> mainInertia
             }
         }
-        if (!torqueMassMultiplier.isFinite() || torqueMassMultiplier <= 0.0) return
+        if (!torqueMassMultiplierBase.isFinite() || torqueMassMultiplierBase <= 0.0) {
+            servoApparentInertiaScale = lowPass(servoApparentInertiaScale, 1.0, SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA)
+            servoPrevOmegaActualForApparentInertiaScaleRadSec = omegaActual
+            servoPrevAppliedHingeTorqueMag = 0.0
+            return
+        }
+        val apparentInertiaScale =
+            updateApparentInertiaScale(torqueMassMultiplierBase, omegaActual, errorForControl, omegaErr)
+        val torqueMassMultiplier = torqueMassMultiplierBase * apparentInertiaScale
+        if (!torqueMassMultiplier.isFinite() || torqueMassMultiplier <= 0.0) {
+            servoPrevAppliedHingeTorqueMag = 0.0
+            return
+        }
+
+        // Strong translational lock at the anchors, plus off-axis angular swing lock.
+        applyAnchorSeatStabilizer(updated, subShip, mainShip)
+        applyOffAxisAngularStabilizer(updated, subShip, mainShip, axisWorld, relOmegaWorld)
 
         // Torque servo: tau = I_eff * alpha_cmd.
         var servoTorqueMag = torqueMassMultiplier * alphaCmd
@@ -956,7 +1166,11 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
 
         val torqueMag = (servoTorqueMag + dampingTorqueMag).coerceIn(-maxTorque, maxTorque)
-        if (!torqueMag.isFinite()) return
+        if (!torqueMag.isFinite()) {
+            servoPrevAppliedHingeTorqueMag = 0.0
+            return
+        }
+        servoPrevAppliedHingeTorqueMag = torqueMag
 
         val torqueVec = axisWorld.mul(torqueMag, Vector3d())
         if (!subShip.isStatic) {
@@ -1822,6 +2036,30 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_ALPHA_FILTER_ALPHA_ACTIVE = 0.95
         private const val SERVO_HOLD_MAX_OMEGA_STEP_PER_TICK = 0.30
         private const val SERVO_ACTIVE_MAX_OMEGA_STEP_PER_TICK = 1.6
+        // Chain attenuation is slider-aware: low slider = more damping bias, high slider = recover full authority.
+        private const val SERVO_CHAIN_AUTHORITY_BLEND_START = 0.20
+        private const val SERVO_CHAIN_AUTHORITY_BLEND_END = 0.70
+        private const val SERVO_CHAIN_COUPLED_EQ_MAX_RATIO = 8.0
+
+        // Apparent inertia compensation:
+        // Estimate effective hinge inertia from previous applied torque vs observed omega response, then scale
+        // authority up for downstream chained loads so nested ships behave closer to one rigid assembly.
+        private const val SERVO_APPARENT_INERTIA_MAX_SCALE_MIN_STRENGTH = 2.0
+        private const val SERVO_APPARENT_INERTIA_MAX_SCALE_MAX_STRENGTH = 16.0
+        private const val SERVO_APPARENT_INERTIA_STABILIZER_SHARE = 0.50
+        private const val SERVO_APPARENT_INERTIA_STABILIZER_MAX_SCALE = 6.0
+        private const val SERVO_APPARENT_INERTIA_MIN_BASE = 1.0e-3
+        private const val SERVO_APPARENT_INERTIA_MIN_OBS_TORQUE = 1.0e6
+        private const val SERVO_APPARENT_INERTIA_ALPHA_FLOOR_RAD_SEC2 = 0.20
+        private const val SERVO_APPARENT_INERTIA_ACTIVE_ERROR_RAD = 0.015
+        private const val SERVO_APPARENT_INERTIA_ACTIVE_OMEGA_ERR_RAD_SEC = 0.40
+        private const val SERVO_APPARENT_INERTIA_RISE_ALPHA = 0.30
+        private const val SERVO_APPARENT_INERTIA_FALL_ALPHA = 0.06
+        private const val SERVO_APPARENT_INERTIA_OPPOSED_DECAY_ALPHA = 0.05
+        private const val SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA = 0.02
+        private const val SERVO_APPARENT_INERTIA_SETTLED_ERROR_RAD = 0.01
+        private const val SERVO_APPARENT_INERTIA_SETTLED_OMEGA_RAD_SEC = 0.10
+        private const val SERVO_APPARENT_INERTIA_SETTLED_DECAY_ALPHA = 0.12
 
         // Hinge-axis explicit damping: tau_damp = -c * omega (c = I_eff * damping_rate).
         // Applied in LOCKED/aligning or when close to target with near-zero command.
@@ -1850,6 +2088,12 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_SEAT_MAX_ACCEL_WORLD_ANCHOR = 8.0
         private const val SERVO_SEAT_WORLD_ANCHOR_KP_SCALE = 0.35
         private const val SERVO_SEAT_WORLD_ANCHOR_KD_SCALE = 0.65
+        private const val SERVO_SEAT_MAX_ACCEL_CHAIN = 12.0
+        private const val SERVO_SEAT_CHAIN_WN_SCALE = 0.90
+        private const val SERVO_SEAT_CHAIN_KP_SCALE = 0.60
+        private const val SERVO_SEAT_CHAIN_KD_SCALE = 1.00
+        private const val SERVO_SEAT_CHAIN_ERROR_DEADBAND_M = 1.2e-3
+        private const val SERVO_SEAT_CHAIN_VEL_DEADBAND = 0.03
         private const val SERVO_SEAT_ERROR_DEADBAND_M = 1.0e-3
         private const val SERVO_SEAT_VEL_DEADBAND = 0.02
         private const val SERVO_SEAT_FORCE_LIMIT_MIN = 5.0e5
@@ -1864,11 +2108,20 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_TILT_MAX_ERROR_RAD = 0.4
         private const val SERVO_TILT_DAMP_ONLY_ERROR_RAD = 0.01
         private const val SERVO_TILT_FULL_STIFFNESS_ERROR_RAD = 0.12
+        private const val SERVO_TILT_CHAIN_DAMP_ONLY_ERROR_RAD = 0.012
+        private const val SERVO_TILT_CHAIN_FULL_STIFFNESS_ERROR_RAD = 0.10
+        private const val SERVO_TILT_CHAIN_OMEGA_DEADBAND = 0.006
+        private const val SERVO_TILT_CHAIN_WN_SCALE = 0.55
+        private const val SERVO_TILT_CHAIN_KP_SCALE = 0.85
+        private const val SERVO_TILT_CHAIN_KD_SCALE = 1.10
         private const val SERVO_TILT_WORLD_ANCHOR_WN_SCALE = 0.35
+        private const val SERVO_TILT_WORLD_ANCHOR_KD_SCALE = 1.15
+        private const val SERVO_TILT_MAX_ALPHA_CHAIN = 60.0
         private const val SERVO_TILT_MAX_ALPHA_WORLD_ANCHOR = 20.0
         private const val SERVO_TILT_MAX_ALPHA_HARD = 200.0 // rad/s^2 hard stability clamp
         private const val SERVO_TILT_MAX_ALPHA_EQUIV = 12.0
         private const val SERVO_TILT_MAX_ALPHA_EQUIV_WORLD_ANCHOR = 4.0
+        private const val SERVO_TILT_MAX_ALPHA_EQUIV_CHAIN = 7.0
         private const val SERVO_TILT_TORQUE_MIN = 1.0e6
         private const val SERVO_TILT_TORQUE_MAX = 5.0e11
 
@@ -1884,6 +2137,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_REANCHOR_MAX_REL_VEL_MPS = 0.12
         private const val SERVO_REANCHOR_MIN_MOTION_SCALE = 0.20
         private const val SERVO_REANCHOR_MIN_STEP = 0.003
+        private const val SERVO_REANCHOR_CHAIN_MAX_HINGE_OMEGA_RAD_SEC = 0.10
+        private const val SERVO_REANCHOR_CHAIN_MAX_REL_VEL_MPS = 0.05
+        private const val SERVO_REANCHOR_CHAIN_STEP_SCALE = 0.45
 
         // Extremely stiff, but not pathological (avoid ~1e-100 which can blow up solvers).
         private const val SERVO_COMPLIANCE = 1.0e-10

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -141,16 +141,27 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     @Volatile private var followOmegaFeedForwardRadSec: Double = 0.0
 
     private var servoStrengthBehaviour: ServoStrengthScrollValueBehaviour? = null
-    private var servoStiffnessBehaviour: ServoStiffnessScrollValueBehaviour? = null
 
     @Volatile private var servoStrengthSetting: Int = SERVO_STRENGTH_DEFAULT
-    @Volatile private var servoStiffnessSetting: Int = SERVO_STIFFNESS_DEFAULT
 
     // Derived (phys-thread) servo parameters.
-    @Volatile private var servoKp: Double = SERVO_KP
-    @Volatile private var servoKd: Double = SERVO_KD
-    @Volatile private var servoMaxAlpha: Double = SERVO_MAX_ALPHA
-    @Volatile private var servoTorqueLimit: Double = SERVO_MAX_TORQUE.toDouble()
+    // Cascaded control:
+    //   omega_from_error = clamp(posGain * angle_error)
+    //   alpha_cmd = omegaGain * (omega_target - omega_actual)
+    @Volatile private var servoPosGain: Double = 0.0
+    @Volatile private var servoOmegaGain: Double = 0.0
+    @Volatile private var servoPosOmegaLimit: Double = 0.0
+    @Volatile private var servoTorqueLimit: Double = 0.0
+    @Volatile private var servoSeatWn: Double = 0.0
+    @Volatile private var servoSeatDampingRatio: Double = 0.0
+    @Volatile private var servoSeatForceLimit: Double = 0.0
+    @Volatile private var servoTiltWn: Double = 0.0
+    @Volatile private var servoTiltDampingRatio: Double = 0.0
+    @Volatile private var servoTiltTorqueLimit: Double = 0.0
+    private var physServoTickCounter: Int = 0
+    // Phys-thread filtered feedback used to avoid exciting solver jitter near hold.
+    @Volatile private var servoOmegaActualFilteredRadSec: Double = 0.0
+    @Volatile private var servoAlphaCmdFilteredRadSec2: Double = 0.0
 
     private var controllerCreationData: PhysBearingData? = null
     private var controllerUpdateData: PhysBearingUpdateData? = null
@@ -189,35 +200,12 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             it.requiresWrench()
             behaviours.add(it)
         }
-
-        servoStiffnessBehaviour = ServoStiffnessScrollValueBehaviour(
-            Component.translatable("$MOD_ID.phys_bearing.servo_stiffness"),
-            this,
-            ServoSettingValueBoxTransform(8.0, 12.0)
-        ).also {
-            it.between(SERVO_STIFFNESS_MIN, SERVO_STIFFNESS_MAX)
-            it.currentValue = servoStiffnessSetting
-            it.withCallback { v -> setServoStiffnessSetting(v, sendUpdate = true) }
-            it.requiresWrench()
-            behaviours.add(it)
-        }
     }
 
     private fun setServoStrengthSetting(value: Int, sendUpdate: Boolean) {
         val clamped = value.coerceIn(SERVO_STRENGTH_MIN, SERVO_STRENGTH_MAX)
         if (servoStrengthSetting == clamped) return
         servoStrengthSetting = clamped
-        recomputeServoTuning()
-        if (sendUpdate && level != null && !level!!.isClientSide) {
-            updateDrive()
-            sendData()
-        }
-    }
-
-    private fun setServoStiffnessSetting(value: Int, sendUpdate: Boolean) {
-        val clamped = value.coerceIn(SERVO_STIFFNESS_MIN, SERVO_STIFFNESS_MAX)
-        if (servoStiffnessSetting == clamped) return
-        servoStiffnessSetting = clamped
         recomputeServoTuning()
         if (sendUpdate && level != null && !level!!.isClientSide) {
             updateDrive()
@@ -233,29 +221,139 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     }
 
     private fun recomputeServoTuning() {
-        val strengthT = servoStrengthSetting.toDouble() / SERVO_STRENGTH_MAX.toDouble()
-        val stiffnessT = servoStiffnessSetting.toDouble() / SERVO_STIFFNESS_MAX.toDouble()
+        val tuneT = servoStrengthSetting.toDouble() / SERVO_STRENGTH_MAX.toDouble()
+        val sliderScale = SERVO_SLIDER_TEST_SCALE.coerceAtLeast(0.0)
+        val tuneTClamped = tuneT.coerceIn(0.0, 1.0)
 
-        val wn = lerpLog(SERVO_WN_MIN, SERVO_WN_MAX, stiffnessT.coerceIn(0.0, 1.0))
-        val testScale = SERVO_TEST_SCALE
-        servoKp = wn * wn * testScale
-        servoKd = 2.0 * SERVO_DAMPING_RATIO * wn * testScale
+        // Single slider drives all control aggressiveness and authority.
+        var wn = lerpLog(SERVO_WN_MIN, SERVO_WN_MAX, tuneTClamped) * sliderScale
+        val maxError = max(SERVO_MAX_ERROR_RAD, 1.0e-3)
+        val wnCap = sqrt(SERVO_MAX_ALPHA_HARD / maxError)
+        wn = wn.coerceAtMost(wnCap)
+        val dampingRatio = (SERVO_DAMPING_RATIO_MIN +
+            (SERVO_DAMPING_RATIO_MAX - SERVO_DAMPING_RATIO_MIN) * tuneTClamped) * sliderScale
 
-        servoMaxAlpha = lerpLog(SERVO_ALPHA_MIN, SERVO_ALPHA_MAX, strengthT.coerceIn(0.0, 1.0)) * testScale
-        servoTorqueLimit = lerpLog(SERVO_FORCE_TORQUE_MIN, SERVO_FORCE_TORQUE_MAX, strengthT.coerceIn(0.0, 1.0)) * testScale
+        // Cascaded gains:
+        // - posGain maps angle error -> target omega.
+        // - omegaGain maps omega error -> target angular acceleration.
+        servoPosGain = wn
+        servoOmegaGain = 2.0 * dampingRatio * wn
+        servoPosOmegaLimit = (lerpLog(SERVO_POS_OMEGA_LIMIT_MIN, SERVO_POS_OMEGA_LIMIT_MAX, tuneTClamped) * sliderScale)
+            .coerceAtMost(SERVO_MAX_OMEGA)
+
+        // Authority limits.
+        servoTorqueLimit =
+            lerpLog(SERVO_TORQUE_MIN, SERVO_TORQUE_MAX, tuneTClamped) * sliderScale
+
+        // Anchor-seat controller (position lock).
+        val seatWnRaw = lerpLog(SERVO_SEAT_WN_MIN, SERVO_SEAT_WN_MAX, tuneTClamped) * sliderScale
+        val seatWnCap = sqrt(SERVO_SEAT_MAX_ACCEL_HARD / max(SERVO_SEAT_MAX_ERROR_M, 1.0e-3))
+        servoSeatWn = seatWnRaw.coerceAtMost(seatWnCap)
+        servoSeatDampingRatio = (SERVO_SEAT_DAMPING_RATIO_MIN +
+            (SERVO_SEAT_DAMPING_RATIO_MAX - SERVO_SEAT_DAMPING_RATIO_MIN) * tuneTClamped) * sliderScale
+        servoSeatForceLimit = lerpLog(SERVO_SEAT_FORCE_LIMIT_MIN, SERVO_SEAT_FORCE_LIMIT_MAX, tuneTClamped) * sliderScale
+
+        // Off-axis orientation lock (swing lock, not twist lock).
+        val tiltWnRaw = lerpLog(SERVO_TILT_WN_MIN, SERVO_TILT_WN_MAX, tuneTClamped) * sliderScale
+        val tiltWnCap = sqrt(SERVO_TILT_MAX_ALPHA_HARD / max(SERVO_TILT_MAX_ERROR_RAD, 1.0e-3))
+        servoTiltWn = tiltWnRaw.coerceAtMost(tiltWnCap)
+        servoTiltDampingRatio = (SERVO_TILT_DAMPING_RATIO_MIN +
+            (SERVO_TILT_DAMPING_RATIO_MAX - SERVO_TILT_DAMPING_RATIO_MIN) * tuneTClamped) * sliderScale
+        servoTiltTorqueLimit = lerpLog(SERVO_TILT_TORQUE_MIN, SERVO_TILT_TORQUE_MAX, tuneTClamped) * sliderScale
+    }
+
+    private fun computeJointMaxForceTorque(): VSJointMaxForceTorque {
+        val torqueLimit = servoTorqueLimit
+        val maxTorque = if (torqueLimit.isFinite() && torqueLimit > 0.0) torqueLimit else SERVO_TORQUE_MIN
+        return VSJointMaxForceTorque(SERVO_JOINT_MAX_FORCE, maxTorque.toFloat())
+    }
+
+    private fun Vector3dc.isFiniteVec(): Boolean {
+        return x().isFinite() && y().isFinite() && z().isFinite()
+    }
+
+    private fun maybeReanchorJoint(
+        joint: VSRevoluteJoint,
+        subShip: PhysShip,
+        mainShip: PhysShip?,
+        hingeOmegaRadSec: Double
+    ): VSRevoluteJoint {
+        if (SERVO_REANCHOR_PERIOD_TICKS <= 0) return joint
+        physServoTickCounter++
+        if (physServoTickCounter % SERVO_REANCHOR_PERIOD_TICKS != 0) return joint
+
+        val anchor0World = subShip.transform.shipToWorld.transformPosition(joint.pose0.pos, Vector3d())
+
+        // Anchor 1 is defined by the bearing block position in the main frame (ship or world).
+        val pose1Local = Vector3d(worldPosition.center.toJOML()).fma(-SERVO_JOINT_ANCHOR_OFFSET, bearingAxis, Vector3d())
+        val anchor1World =
+            if (mainShip != null) mainShip.transform.shipToWorld.transformPosition(pose1Local, Vector3d()) else pose1Local
+
+        if (!anchor0World.isFiniteVec() || !anchor1World.isFiniteVec()) return joint
+        val subAnchorVel = getPointVelocityWorld(subShip, anchor0World)
+        val mainAnchorVel = if (mainShip != null) getPointVelocityWorld(mainShip, anchor1World) else Vector3d()
+        val relAnchorVel = mainAnchorVel.sub(subAnchorVel, Vector3d())
+        val relAnchorSpeed = relAnchorVel.length()
+        val absHingeOmega = abs(hingeOmegaRadSec)
+        if (!relAnchorSpeed.isFinite() || !absHingeOmega.isFinite()) return joint
+        if (absHingeOmega > SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC || relAnchorSpeed > SERVO_REANCHOR_MAX_REL_VEL_MPS) return joint
+
+        // As hinge/anchor motion rises, shrink reanchor corrections to avoid injecting impulses.
+        val motionRatio = max(
+            absHingeOmega / max(SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC, 1.0e-6),
+            relAnchorSpeed / max(SERVO_REANCHOR_MAX_REL_VEL_MPS, 1.0e-6)
+        )
+        val motionScale = (1.0 - motionRatio).coerceIn(0.0, 1.0)
+        if (motionScale < SERVO_REANCHOR_MIN_MOTION_SCALE) return joint
+
+        val err = anchor0World.distance(anchor1World)
+        if (!err.isFinite()) return joint
+        if (err < SERVO_REANCHOR_POS_EPS) return joint
+
+        // Don't do large corrections in one go; that can introduce impulses. Nudge toward the desired anchor.
+        val deltaWorld = anchor1World.sub(anchor0World, Vector3d())
+        val maxStepNow = SERVO_REANCHOR_MAX_STEP * motionScale
+        if (maxStepNow < SERVO_REANCHOR_MIN_STEP) return joint
+        val step = min(err, maxStepNow)
+        val targetWorld = if (err > 0.0) {
+            anchor0World.add(deltaWorld.mul(step / err, Vector3d()), Vector3d())
+        } else {
+            anchor1World
+        }
+
+        val newPose0Pos = subShip.transform.worldToShip.transformPosition(targetWorld, Vector3d())
+        val newPose0 = VSJointPose(newPose0Pos, joint.pose0.rot)
+        val newPose1 = VSJointPose(pose1Local, joint.pose1.rot)
+
+        if (DEBUG_SERVO) {
+            ClockworkMod.LOGGER.info(
+                "[PhysBearing] re-anchor (err={}, step={}, motionScale={}, relVel={}, omega={}, jointId={}, ship0={}, ship1={})",
+                err,
+                step,
+                motionScale,
+                relAnchorSpeed,
+                absHingeOmega,
+                jointID,
+                joint.shipId0,
+                joint.shipId1
+            )
+        }
+
+        return joint.copy(pose0 = newPose0, pose1 = newPose1)
     }
 
     private fun updateDrive() {
         val level = level as? ServerLevel ?: return
         val existing = joint ?: return
         val mode = movementMode?.get() ?: LockedMode.UNLOCKED
+        val maxForceTorque = computeJointMaxForceTorque()
 
         // Keep the joint REVOLUTE in all modes; servo is implemented via driveVelocity in physTick.
         val revolute = when (existing) {
             is VSRevoluteJoint -> existing
             is VSFixedJoint -> VSRevoluteJoint(
                 existing.shipId0, existing.pose0, existing.shipId1, existing.pose1,
-                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                maxForceTorque = maxForceTorque,
                 compliance = SERVO_COMPLIANCE,
                 driveFreeSpin = true
             )
@@ -265,7 +363,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val servoActive = aligning || mode != LockedMode.UNLOCKED
         val baseJoint = if (servoActive) {
             revolute.copy(
-                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                maxForceTorque = maxForceTorque,
                 compliance = SERVO_COMPLIANCE,
                 // We don't rely on the revolute motor for servo behavior; see physTick torque servo.
                 driveVelocity = null,
@@ -275,10 +373,11 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             )
         } else {
             revolute.copy(
-                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                maxForceTorque = maxForceTorque,
                 compliance = SERVO_COMPLIANCE,
                 driveVelocity = null,
                 driveForceLimit = null,
+                driveGearRatio = null,
                 driveFreeSpin = true
             )
         }
@@ -308,6 +407,29 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         // Returns error in (-pi, pi].
         val d = target - current
         return atan2(sin(d), cos(d))
+    }
+
+    private fun lerpClamped(min: Double, max: Double, t: Double): Double {
+        val tc = t.coerceIn(0.0, 1.0)
+        return min + (max - min) * tc
+    }
+
+    private fun smoothStep(edge0: Double, edge1: Double, x: Double): Double {
+        if (edge1 <= edge0) return if (x >= edge1) 1.0 else 0.0
+        val t = ((x - edge0) / (edge1 - edge0)).coerceIn(0.0, 1.0)
+        return t * t * (3.0 - 2.0 * t)
+    }
+
+    private fun lowPass(previous: Double, sample: Double, alpha: Double): Double {
+        if (!sample.isFinite()) return previous
+        if (!previous.isFinite()) return sample
+        val a = alpha.coerceIn(0.0, 1.0)
+        return previous + (sample - previous) * a
+    }
+
+    private fun clearServoFilterState() {
+        servoOmegaActualFilteredRadSec = 0.0
+        servoAlphaCmdFilteredRadSec2 = 0.0
     }
 
     private fun normalizeAngleDeg0To720(angleDeg: Double): Float {
@@ -448,6 +570,215 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         return 1.0 / (1.0 / left + 1.0 / right)
     }
 
+    private fun rejectAlongAxis(vec: Vector3dc, axisUnit: Vector3dc): Vector3d {
+        return vec.sub(axisUnit.mul(axisUnit.dot(vec), Vector3d()), Vector3d())
+    }
+
+    private fun getPointVelocityWorld(ship: PhysShip, pointWorld: Vector3dc): Vector3d {
+        val r = pointWorld.sub(ship.transform.positionInWorld, Vector3d())
+        return ship.velocity.add(Vector3d(ship.angularVelocity).cross(r, Vector3d()), Vector3d())
+    }
+
+    private fun computeSwingErrorWorld(
+        subShip: PhysShip,
+        mainShip: PhysShip?,
+        axisWorldUnit: Vector3dc
+    ): Vector3d {
+        val subRotWorld = Quaterniond(subShip.transform.shipToWorldRotation)
+        val mainRotWorld = if (mainShip != null) Quaterniond(mainShip.transform.shipToWorldRotation) else Quaterniond()
+
+        // Relative rotation from main to sub.
+        val qRel = Quaterniond(mainRotWorld).conjugate().mul(subRotWorld, Quaterniond()).normalize()
+
+        // Decompose qRel into swing/twist around the hinge axis (in main frame), then keep swing only.
+        val axisMain = Quaterniond(mainRotWorld).conjugate().transform(axisWorldUnit, Vector3d())
+        if (axisMain.lengthSquared() < 1.0e-9) return Vector3d()
+        axisMain.normalize()
+
+        val relVecMain = Vector3d(qRel.x, qRel.y, qRel.z)
+        val projected = axisMain.mul(relVecMain.dot(axisMain), Vector3d())
+        val twist = Quaterniond(projected.x, projected.y, projected.z, qRel.w)
+        val twistUnit = if (twist.lengthSquared() < 1.0e-12) Quaterniond() else twist.normalize()
+        val swing = qRel.mul(Quaterniond(twistUnit).conjugate(), Quaterniond()).normalize()
+
+        val swingVecMain = Vector3d(swing.x, swing.y, swing.z)
+        val swingVecLen = swingVecMain.length()
+        if (swingVecLen < 1.0e-9 || !swingVecLen.isFinite()) return Vector3d()
+
+        var angle = 2.0 * atan2(swingVecLen, swing.w.coerceIn(-1.0, 1.0))
+        if (angle > Math.PI) angle -= Math.PI * 2.0
+        if (!angle.isFinite()) return Vector3d()
+
+        val swingAxisMain = swingVecMain.mul(1.0 / swingVecLen, Vector3d())
+        val errorMain = swingAxisMain.mul(angle, Vector3d())
+        return mainRotWorld.transform(errorMain, Vector3d())
+    }
+
+    private fun applyAnchorSeatStabilizer(
+        joint: VSRevoluteJoint,
+        subShip: PhysShip,
+        mainShip: PhysShip?
+    ) {
+        val subDynamic = !subShip.isStatic
+        val mainDynamic = mainShip != null && !mainShip.isStatic
+        if (!subDynamic && !mainDynamic) return
+
+        val anchor0World = subShip.transform.shipToWorld.transformPosition(joint.pose0.pos, Vector3d())
+        val anchor1World = if (mainShip != null) {
+            mainShip.transform.shipToWorld.transformPosition(joint.pose1.pos, Vector3d())
+        } else {
+            joint.pose1.pos.get(Vector3d())
+        }
+        if (!anchor0World.isFiniteVec() || !anchor1World.isFiniteVec()) return
+
+        // Revolute should keep anchors coincident in all directions.
+        val anchorErrorRaw = anchor1World.sub(anchor0World, Vector3d())
+        val subAnchorVel = if (subDynamic) getPointVelocityWorld(subShip, anchor0World) else Vector3d()
+        val mainAnchorVel = if (mainDynamic) getPointVelocityWorld(mainShip!!, anchor1World) else Vector3d()
+        val relVel = mainAnchorVel.sub(subAnchorVel, Vector3d())
+        val errorLen = anchorErrorRaw.length()
+        val relVelLen = relVel.length()
+        if (errorLen < SERVO_SEAT_ERROR_DEADBAND_M && relVelLen < SERVO_SEAT_VEL_DEADBAND) return
+        val anchorError = if (errorLen > SERVO_SEAT_MAX_ERROR_M && errorLen > 1.0e-9) {
+            anchorErrorRaw.mul(SERVO_SEAT_MAX_ERROR_M / errorLen, Vector3d())
+        } else {
+            anchorErrorRaw
+        }
+
+        val effMass = when {
+            subDynamic && mainDynamic -> parallelOperator(subShip.mass, mainShip!!.mass)
+            subDynamic -> subShip.mass
+            else -> mainShip!!.mass
+        }
+        if (!effMass.isFinite() || effMass <= 0.0) return
+
+        val sliderScale = SERVO_SLIDER_TEST_SCALE.coerceAtLeast(0.0)
+        val worldAnchored = mainShip == null || mainShip.isStatic
+        val seatWn = servoSeatWn.coerceIn(0.0, SERVO_SEAT_WN_MAX * sliderScale)
+        val seatDamping = servoSeatDampingRatio.coerceIn(0.0, SERVO_SEAT_DAMPING_RATIO_MAX * sliderScale)
+        val seatKpScale = if (worldAnchored) SERVO_SEAT_WORLD_ANCHOR_KP_SCALE else 1.0
+        val seatKdScale = if (worldAnchored) SERVO_SEAT_WORLD_ANCHOR_KD_SCALE else 1.0
+        val seatKp = seatWn * seatWn * seatKpScale
+        val seatKd = 2.0 * seatDamping * seatWn * seatKdScale
+
+        var seatAccCmd = anchorError.mul(seatKp, Vector3d()).add(relVel.mul(seatKd, Vector3d()))
+        if (!seatAccCmd.isFiniteVec()) return
+        val maxSeatAccel = if (worldAnchored) SERVO_SEAT_MAX_ACCEL_WORLD_ANCHOR else SERVO_SEAT_MAX_ACCEL_HARD
+        val seatAccLen = seatAccCmd.length()
+        if (seatAccLen > maxSeatAccel && seatAccLen > 1.0e-9) {
+            seatAccCmd.mul(maxSeatAccel / seatAccLen)
+        }
+
+        var seatForce = seatAccCmd.mul(effMass, Vector3d())
+        if (!seatForce.isFiniteVec()) return
+
+        val minSeatForce = SERVO_SEAT_FORCE_LIMIT_MIN * sliderScale
+        val maxSeatForceCap = SERVO_SEAT_FORCE_LIMIT_MAX * sliderScale
+        val maxSeatForce = if (servoSeatForceLimit.isFinite() && servoSeatForceLimit > 0.0) {
+            servoSeatForceLimit.coerceIn(minSeatForce, maxSeatForceCap)
+        } else {
+            minSeatForce
+        }
+        val seatForceLen = seatForce.length()
+        if (seatForceLen > maxSeatForce && seatForceLen > 1.0e-9) {
+            seatForce.mul(maxSeatForce / seatForceLen)
+        }
+
+        if (subDynamic) {
+            subShip.applyWorldForceToModelPos(seatForce, joint.pose0.pos.get(Vector3d()))
+        }
+        if (mainDynamic) {
+            mainShip!!.applyWorldForceToModelPos(seatForce.mul(-1.0, Vector3d()), joint.pose1.pos.get(Vector3d()))
+        }
+    }
+
+    private fun applyOffAxisAngularStabilizer(
+        joint: VSRevoluteJoint,
+        subShip: PhysShip,
+        mainShip: PhysShip?,
+        axisWorldUnit: Vector3dc,
+        relOmegaWorld: Vector3dc
+    ) {
+        val subDynamic = !subShip.isStatic
+        val mainDynamic = mainShip != null && !mainShip.isStatic
+        if (!subDynamic && !mainDynamic) return
+
+        val swingErrorWorldRaw = computeSwingErrorWorld(subShip, mainShip, axisWorldUnit)
+        val swingErrorLen = swingErrorWorldRaw.length()
+        val swingErrorWorld = if (swingErrorLen > SERVO_TILT_MAX_ERROR_RAD && swingErrorLen > 1.0e-9) {
+            swingErrorWorldRaw.mul(SERVO_TILT_MAX_ERROR_RAD / swingErrorLen, Vector3d())
+        } else {
+            swingErrorWorldRaw
+        }
+        val offAxisOmega = rejectAlongAxis(relOmegaWorld, axisWorldUnit)
+        val offAxisOmegaLen = offAxisOmega.length()
+        if ((!offAxisOmegaLen.isFinite() || offAxisOmegaLen < SERVO_TILT_OMEGA_DEADBAND) && swingErrorWorld.length() < 1.0e-6) return
+
+        val sliderScale = SERVO_SLIDER_TEST_SCALE.coerceAtLeast(0.0)
+        val worldAnchored = mainShip == null || mainShip.isStatic
+        val tiltWnScale = if (worldAnchored) SERVO_TILT_WORLD_ANCHOR_WN_SCALE else 1.0
+        val tiltWn = (servoTiltWn.coerceIn(0.0, SERVO_TILT_WN_MAX * sliderScale) * tiltWnScale)
+        val tiltDamping = servoTiltDampingRatio.coerceIn(0.0, SERVO_TILT_DAMPING_RATIO_MAX * sliderScale)
+        val tiltKp = tiltWn * tiltWn
+        val tiltKd = 2.0 * tiltDamping * tiltWn
+        val stiffnessBlend =
+            smoothStep(SERVO_TILT_DAMP_ONLY_ERROR_RAD, SERVO_TILT_FULL_STIFFNESS_ERROR_RAD, swingErrorWorld.length())
+
+        var tiltAlphaCmd = swingErrorWorld.mul(-tiltKp * stiffnessBlend, Vector3d()).add(offAxisOmega.mul(-tiltKd, Vector3d()))
+        if (!tiltAlphaCmd.isFiniteVec()) return
+        var tiltAlphaLen = tiltAlphaCmd.length()
+        val maxTiltAlpha = if (worldAnchored) SERVO_TILT_MAX_ALPHA_WORLD_ANCHOR else SERVO_TILT_MAX_ALPHA_HARD
+        if (tiltAlphaLen > maxTiltAlpha && tiltAlphaLen > 1.0e-9) {
+            tiltAlphaCmd.mul(maxTiltAlpha / tiltAlphaLen)
+            tiltAlphaLen = tiltAlphaCmd.length()
+        }
+
+        val tiltAxis = if (tiltAlphaLen > 1.0e-9) {
+            tiltAlphaCmd.mul(1.0 / tiltAlphaLen, Vector3d())
+        } else if (offAxisOmegaLen > 1.0e-9) {
+            offAxisOmega.mul(1.0 / offAxisOmegaLen, Vector3d())
+        } else {
+            return
+        }
+
+        val effInertia = when {
+            subDynamic && mainDynamic -> {
+                val subInertia = getAngularInertia(subShip, joint.pose0.pos, tiltAxis)
+                val mainInertia = getAngularInertia(mainShip!!, joint.pose1.pos, tiltAxis)
+                parallelOperator(subInertia, mainInertia)
+            }
+            subDynamic -> getAngularInertia(subShip, joint.pose0.pos, tiltAxis)
+            else -> getAngularInertia(mainShip!!, joint.pose1.pos, tiltAxis)
+        }
+        if (!effInertia.isFinite() || effInertia <= 0.0) return
+
+        var tiltTorque = tiltAlphaCmd.mul(effInertia, Vector3d())
+        if (!tiltTorque.isFiniteVec()) return
+        val maxTiltTorque = if (servoTiltTorqueLimit.isFinite() && servoTiltTorqueLimit > 0.0) {
+            servoTiltTorqueLimit
+        } else {
+            SERVO_TILT_TORQUE_MIN * sliderScale
+        }
+        val maxTiltTorqueByAlpha = effInertia * if (worldAnchored) {
+            SERVO_TILT_MAX_ALPHA_EQUIV_WORLD_ANCHOR
+        } else {
+            SERVO_TILT_MAX_ALPHA_EQUIV
+        }
+        val clampedMaxTiltTorque = min(maxTiltTorque, maxTiltTorqueByAlpha)
+        if (!clampedMaxTiltTorque.isFinite() || clampedMaxTiltTorque <= 0.0) return
+        val tiltTorqueLen = tiltTorque.length()
+        if (tiltTorqueLen > clampedMaxTiltTorque && tiltTorqueLen > 1.0e-9) {
+            tiltTorque.mul(clampedMaxTiltTorque / tiltTorqueLen)
+        }
+
+        if (subDynamic) {
+            subShip.applyWorldTorque(tiltTorque)
+        }
+        if (mainDynamic) {
+            mainShip!!.applyWorldTorque(tiltTorque.mul(-1.0, Vector3d()))
+        }
+    }
+
     override fun physTick(physShip: PhysShip?, physLevel: PhysLevel) {
         if (isRemoved || !isRunning) return
         val jointId = jointID
@@ -456,7 +787,10 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val revolute = joint as? VSRevoluteJoint ?: return
         val mode = servoMode
         val servoActive = aligning || mode != LockedMode.UNLOCKED
-        if (!servoActive) return
+        if (!servoActive) {
+            clearServoFilterState()
+            return
+        }
 
         // We need both transforms to compute angle; if ships aren't loaded yet, just wait.
         val subShip = revolute.shipId0?.let { physLevel.getShipById(it) } ?: run {
@@ -471,42 +805,109 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             mode == LockedMode.LOCKED -> lockedHoldAngleRad ?: currentAngleRad.also { lockedHoldAngleRad = it }
             else -> Math.toRadians(targetAngle.toDouble())
         }
+        if (!currentAngleRad.isFinite() || !targetAngleRad.isFinite()) return
 
         var errorRad = shortestAngleErrorRad(targetAngleRad, currentAngleRad)
         if (abs(errorRad) < SERVO_DEADBAND_RAD) errorRad = 0.0
         val axisWorld = bearingAxis.get(Vector3d())
         mainShip?.transform?.shipToWorldRotation?.transform(axisWorld)
+        if (axisWorld.lengthSquared() < 1.0e-9) return
+        axisWorld.normalize()
 
         val relOmegaWorld = Vector3d(subShip.angularVelocity)
         if (mainShip != null) relOmegaWorld.sub(mainShip.angularVelocity)
-        val omegaActual = relOmegaWorld.dot(axisWorld) // rad/s along the bearing axis
+        val omegaActualRaw = relOmegaWorld.dot(axisWorld) // rad/s along the bearing axis
+        if (!omegaActualRaw.isFinite()) return
+        val errorForControl = errorRad.coerceIn(-SERVO_MAX_ERROR_RAD, SERVO_MAX_ERROR_RAD)
+        val holdBlend = smoothStep(SERVO_HOLD_BLEND_ERROR_RAD, SERVO_HOLD_RELEASE_ERROR_RAD, abs(errorForControl))
+
+        val omegaFilterAlpha = lerpClamped(SERVO_OMEGA_FILTER_ALPHA_NEAR_HOLD, SERVO_OMEGA_FILTER_ALPHA_ACTIVE, holdBlend)
+        servoOmegaActualFilteredRadSec = lowPass(servoOmegaActualFilteredRadSec, omegaActualRaw, omegaFilterAlpha)
+        val omegaActual = if (servoOmegaActualFilteredRadSec.isFinite()) {
+            servoOmegaActualFilteredRadSec
+        } else {
+            omegaActualRaw
+        }
 
         // FOLLOW_ANGLE should respond immediately to kinetic input; use a feed-forward target omega and a PD in
         // acceleration-space. This avoids the "infinite torque" behavior that destabilizes heavy/offset ships.
-        val omegaFf = if (!aligning && mode == LockedMode.FOLLOW_ANGLE) {
+        val omegaFfRaw = if (!aligning && mode == LockedMode.FOLLOW_ANGLE && !followAngleStalled) {
             followOmegaFeedForwardRadSec.coerceIn(-SERVO_MAX_OMEGA, SERVO_MAX_OMEGA)
         } else {
             0.0
         }
-        val omegaErr = omegaFf - omegaActual
-        val errorForControl = errorRad.coerceIn(-SERVO_MAX_ERROR_RAD, SERVO_MAX_ERROR_RAD)
-        var alphaCmd = servoKp * errorForControl + servoKd * omegaErr
-        alphaCmd = alphaCmd.coerceIn(-servoMaxAlpha, servoMaxAlpha)
+        val followFfScale = if (!aligning && mode == LockedMode.FOLLOW_ANGLE && !followAngleStalled) {
+            smoothStep(FOLLOW_FF_FADE_START_ERROR_RAD, FOLLOW_FF_FADE_END_ERROR_RAD, abs(errorForControl))
+        } else {
+            0.0
+        }
+        var omegaFf = (omegaFfRaw * followFfScale).coerceIn(-SERVO_MAX_OMEGA, SERVO_MAX_OMEGA)
+        if (
+            followAngleStalled ||
+            (abs(errorForControl) < FOLLOW_FF_ZERO_ERROR_RAD && abs(omegaActual) < FOLLOW_FF_ZERO_OMEGA_RAD_SEC)
+        ) {
+            omegaFf = 0.0
+        }
+
+        // Close to hold, fade positional stiffness and let damping dominate.
+        val omegaFromPositionRaw = (servoPosGain * errorForControl).coerceIn(-servoPosOmegaLimit, servoPosOmegaLimit)
+        val omegaFromPosition = omegaFromPositionRaw * holdBlend
+        val omegaTarget = (omegaFromPosition + omegaFf).coerceIn(-SERVO_MAX_OMEGA, SERVO_MAX_OMEGA)
+        val omegaErr = omegaTarget - omegaActual
+        var alphaCmdRaw = servoOmegaGain * omegaErr
+
+        // Prevent tiny setpoint chatter from exciting heavy ships near lock.
+        if (
+            abs(errorForControl) < SERVO_HOLD_ERROR_RAD &&
+            abs(omegaActual) < SERVO_HOLD_OMEGA_RAD_SEC &&
+            abs(omegaTarget) < SERVO_HOLD_OMEGA_RAD_SEC &&
+            abs(omegaFf) < SERVO_HOLD_OMEGA_RAD_SEC
+        ) {
+            alphaCmdRaw = 0.0
+        }
+
+        val alphaFilterAlpha = lerpClamped(SERVO_ALPHA_FILTER_ALPHA_NEAR_HOLD, SERVO_ALPHA_FILTER_ALPHA_ACTIVE, holdBlend)
+        servoAlphaCmdFilteredRadSec2 = lowPass(servoAlphaCmdFilteredRadSec2, alphaCmdRaw, alphaFilterAlpha)
+        var alphaCmd = if (servoAlphaCmdFilteredRadSec2.isFinite()) {
+            servoAlphaCmdFilteredRadSec2
+        } else {
+            alphaCmdRaw
+        }
+
+        // Discrete-time stability clamp: limit per-tick omega step to avoid high-frequency solver excitation.
+        val maxOmegaStepPerTick = lerpClamped(
+            SERVO_HOLD_MAX_OMEGA_STEP_PER_TICK,
+            SERVO_ACTIVE_MAX_OMEGA_STEP_PER_TICK,
+            holdBlend
+        )
+        val alphaLimitByDt = if (SERVO_PHYS_TICK_DT_SEC > 0.0) {
+            maxOmegaStepPerTick / SERVO_PHYS_TICK_DT_SEC
+        } else {
+            SERVO_MAX_ALPHA_HARD
+        }
+        val alphaLimit = min(SERVO_MAX_ALPHA_HARD, alphaLimitByDt.coerceAtLeast(0.0))
+        alphaCmd = alphaCmd.coerceIn(-alphaLimit, alphaLimit)
+        if (!alphaCmd.isFinite()) return
 
         // Ensure the joint isn't treated as free-spin in servo modes. We do NOT rely on the joint motor here because
         // it's backend-dependent; instead we apply an explicit torque servo below.
-        val updated = revolute.copy(
-            maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+        var updated = revolute.copy(
+            maxForceTorque = computeJointMaxForceTorque(),
             compliance = SERVO_COMPLIANCE,
             driveVelocity = null,
             driveForceLimit = null,
             driveGearRatio = null,
             driveFreeSpin = false
         )
+        updated = maybeReanchorJoint(updated, subShip, mainShip, omegaActual)
         if (updated != revolute) {
             joint = updated
             (physLevel as? VsiPhysLevel)?.updateJoint(jointId, updated)
         }
+
+        // Strong translational lock at the anchors, plus off-axis angular swing lock.
+        applyAnchorSeatStabilizer(updated, subShip, mainShip)
+        applyOffAxisAngularStabilizer(updated, subShip, mainShip, axisWorld, relOmegaWorld)
 
         // Torque servo (works even when revolute drive velocity is not honored).
         val torqueMassMultiplier: Double = run {
@@ -523,11 +924,39 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
                 else -> mainInertia
             }
         }
+        if (!torqueMassMultiplier.isFinite() || torqueMassMultiplier <= 0.0) return
 
-        // Torque = I_eff * alpha_cmd, clamped.
-        var torqueMag = torqueMassMultiplier * alphaCmd
-        val maxTorque = servoTorqueLimit
-        torqueMag = torqueMag.coerceIn(-maxTorque, maxTorque)
+        // Torque servo: tau = I_eff * alpha_cmd.
+        var servoTorqueMag = torqueMassMultiplier * alphaCmd
+        if (!servoTorqueMag.isFinite()) return
+        val maxTorque = if (servoTorqueLimit.isFinite() && servoTorqueLimit > 0.0) servoTorqueLimit else SERVO_TORQUE_MIN
+        servoTorqueMag = servoTorqueMag.coerceIn(-maxTorque, maxTorque)
+
+        // Explicit hinge-axis damping torque for hold/near-target operation:
+        // tau_damp = -c * omega, where c = I_eff * damping_rate.
+        val nearTargetForDamping = abs(errorForControl) < SERVO_DAMPING_NEAR_TARGET_ERROR_RAD
+        val commandNearZero =
+            abs(omegaTarget) < SERVO_DAMPING_HOLD_CMD_OMEGA_RAD_SEC &&
+                abs(omegaFfRaw) < SERVO_DAMPING_HOLD_CMD_OMEGA_RAD_SEC
+        val holdLikeState = mode == LockedMode.LOCKED || aligning || nearTargetForDamping
+        val applyHingeDamping =
+            holdLikeState && commandNearZero && abs(omegaActual) >= SERVO_DAMPING_MIN_ACTIVE_OMEGA_RAD_SEC
+
+        var dampingTorqueMag = 0.0
+        if (applyHingeDamping) {
+            val dampingRate =
+                if (mode == LockedMode.LOCKED || aligning) SERVO_HINGE_DAMPING_RATE_LOCKED else SERVO_HINGE_DAMPING_RATE_NEAR_TARGET
+            val dampingCoeff = torqueMassMultiplier * dampingRate
+            dampingTorqueMag = -dampingCoeff * omegaActual
+            val maxDampingTorque = min(
+                maxTorque * SERVO_HINGE_DAMPING_MAX_TORQUE_FRACTION,
+                torqueMassMultiplier * SERVO_HINGE_DAMPING_MAX_ALPHA_EQUIV
+            )
+            dampingTorqueMag = dampingTorqueMag.coerceIn(-maxDampingTorque, maxDampingTorque)
+        }
+
+        val torqueMag = (servoTorqueMag + dampingTorqueMag).coerceIn(-maxTorque, maxTorque)
+        if (!torqueMag.isFinite()) return
 
         val torqueVec = axisWorld.mul(torqueMag, Vector3d())
         if (!subShip.isStatic) {
@@ -597,7 +1026,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             is VSRevoluteJoint -> joint
             is VSFixedJoint -> VSRevoluteJoint(
                 joint.shipId0, joint.pose0, joint.shipId1, joint.pose1,
-                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                maxForceTorque = computeJointMaxForceTorque(),
                 compliance = SERVO_COMPLIANCE,
                 driveFreeSpin = true
             )
@@ -672,7 +1101,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             val fj = mapper.readValue(tag.getByteArray("fjoint"), VSFixedJoint::class.java)
             joint = VSRevoluteJoint(
                 fj.shipId0, fj.pose0, fj.shipId1, fj.pose1,
-                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                maxForceTorque = computeJointMaxForceTorque(),
                 compliance = SERVO_COMPLIANCE,
                 driveFreeSpin = true
             )
@@ -682,7 +1111,6 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         super.read(tag, clientPacket)
         // Behaviours were just read; sync derived servo parameters from the persisted values.
         servoStrengthBehaviour?.also { setServoStrengthSetting(it.currentValue, sendUpdate = false) }
-        servoStiffnessBehaviour?.also { setServoStiffnessSetting(it.currentValue, sendUpdate = false) }
         if (clientPacket) {return}
 
         // may not have level on read so i have to do this
@@ -906,13 +1334,13 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val ship1rot = getHingeRotation(direction)
         val ship2rot = getHingeRotation(direction)
 
-        val extraDist = 1.0
+        val extraDist = SERVO_JOINT_ANCHOR_OFFSET
 //        val realSpeed = if (getSpeed().absoluteValue > 0.0f) getRealisticAngularSpeed() else 0.0f
 //        val newDriveVelocity = if (realSpeed != 0.0f) VSRevoluteJoint.VSRevoluteDriveVelocity(getRealisticAngularSpeed(), true) else null
         joint = VSRevoluteJoint(
             shiptraptionID, VSJointPose(bearingPos.fma(-extraDist, axis, Vector3d()), ship1rot),
             shipOnID, VSJointPose(posInOwnerShip.fma(-extraDist, axis, Vector3d()), ship2rot),
-            maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+            maxForceTorque = computeJointMaxForceTorque(),
             compliance = SERVO_COMPLIANCE,
             driveFreeSpin = true
 //            driveVelocity = newDriveVelocity,
@@ -1030,6 +1458,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         lastAngle = 0f
         curAngle = 0f
 
+        physServoTickCounter = 0
+        clearServoFilterState()
         clearFollowAngleStallState()
     }
 
@@ -1332,31 +1762,6 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
     }
 
-    private class ServoStiffnessScrollValueBehaviour(
-        label: Component,
-        be: GeneratingKineticBlockEntity,
-        slot: ValueBoxTransform
-    ) : ServoTuningScrollValueBehaviour(label, be, slot, 2) {
-
-        override fun getType(): BehaviourType<*> = TYPE
-
-        override fun getClipboardKey(): String = "PhysBearingServoStiffness"
-
-        override fun write(nbt: CompoundTag, clientPacket: Boolean) {
-            nbt.putInt(NBT_KEY, currentValue)
-        }
-
-        override fun read(nbt: CompoundTag, clientPacket: Boolean) {
-            if (nbt.contains(NBT_KEY)) currentValue = nbt.getInt(NBT_KEY)
-        }
-
-        companion object {
-            val TYPE: BehaviourType<ServoStiffnessScrollValueBehaviour> =
-                BehaviourType("phys_bearing_servo_stiffness")
-            private const val NBT_KEY = "ServoStiffness"
-        }
-    }
-
     companion object {
         const val NO_SHIPTRAPTION_ID: Long = -1
 
@@ -1364,23 +1769,28 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_STRENGTH_MIN = 0
         private const val SERVO_STRENGTH_MAX = 100
         private const val SERVO_STRENGTH_DEFAULT = 50
-        private const val SERVO_STIFFNESS_MIN = 0
-        private const val SERVO_STIFFNESS_MAX = 100
-        private const val SERVO_STIFFNESS_DEFAULT = 50
 
         // Slider mapping:
-        // - "Stiffness" controls closed-loop natural frequency (wn), with Kp = wn^2.
-        // - Kd is chosen for a fixed damping ratio to minimize sway/overshoot.
-        // - "Strength" caps both max torque and max angular acceleration.
-        // Temporary: boost slider magnitudes for testing (e.g., UI 100 behaves like 1000 if set to 10.0).
-        private const val SERVO_TEST_SCALE = 2.0
-        private const val SERVO_DAMPING_RATIO = 1.25
-        private const val SERVO_WN_MIN = 4.0
-        private const val SERVO_WN_MAX = 64.0
-        private const val SERVO_ALPHA_MIN = 30.0
-        private const val SERVO_ALPHA_MAX = 480.0
-        private const val SERVO_FORCE_TORQUE_MIN = 1.0e8
-        private const val SERVO_FORCE_TORQUE_MAX = 1.0e10
+        // - Single "Strength" slider controls both stiffness and authority.
+        // - Angular control is acceleration-space:
+        //     omega_from_error = clamp(wn * angle_error)
+        //     alpha_cmd = (2*zeta*wn) * (omega_target - omega_actual)
+        //   Then apply torque = I_eff * alpha_cmd.
+        private const val SERVO_DAMPING_RATIO_MIN = 1.6 // zeta; >= 1 to reduce sway/overshoot
+        private const val SERVO_DAMPING_RATIO_MAX = 2.4
+        private const val SERVO_WN_MIN = 2.0
+        private const val SERVO_WN_MAX = 24.0
+        private const val SERVO_POS_OMEGA_LIMIT_MIN = 3.0
+        private const val SERVO_POS_OMEGA_LIMIT_MAX = 28.0
+
+        // Slider output ranges can be globally amplified for testing.
+        // This scales all slider-driven magnitudes from the shared strength slider.
+        // Hard clamps (omega/alpha/error and seat acceleration/force clamps) remain in effect.
+        private const val SERVO_SLIDER_TEST_SCALE = 1.0
+
+        // Strength -> torque limit (log-mapped).
+        private const val SERVO_TORQUE_MIN = 1.0e7
+        private const val SERVO_TORQUE_MAX = 1.0e10
 
         private const val MISSING_SUBSHIP_GRACE_TICKS = 20
 
@@ -1391,20 +1801,89 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val FOLLOW_STALL_EPS_RAD_BASE = 1.0e-4
         private const val FOLLOW_STALL_EPS_FRACTION = 0.005
 
-        // Servo tuning (acceleration-space PD):
-        //   alpha_cmd = Kp * angle_error + Kd * (omega_target - omega_actual)
-        // Then we apply torque = I_eff * alpha_cmd.
-        private const val SERVO_KP = 250.0 // (rad/s^2)/rad
-        private const val SERVO_KD = 40.0  // (rad/s^2)/(rad/s)
+        // Servo tuning.
         private const val SERVO_MAX_OMEGA = 80.0 // rad/s (feed-forward clamp)
-        private const val SERVO_MAX_ALPHA = 120.0 // rad/s^2 (hard stability clamp)
+        private const val SERVO_MAX_ALPHA_HARD = 180.0 // rad/s^2 (hard stability clamp)
         private const val SERVO_MAX_ERROR_RAD = 0.75 // rad (~43 deg), avoids absurd snap torques on large steps
         private const val SERVO_DEADBAND_RAD = 1.0e-4 // ~0.006 degrees
+        private const val SERVO_HOLD_ERROR_RAD = 2.0e-3 // ~0.11 degrees
+        private const val SERVO_HOLD_OMEGA_RAD_SEC = 0.04
 
-        // Joint strength. Values are intentionally very high to avoid "sagging".
-        private const val SERVO_MAX_FORCE = 1.0e9f
-        private const val SERVO_MAX_TORQUE = 1.0e9f
-        private const val SERVO_DRIVE_FORCE_LIMIT = 1.0e9f
+        // Near hold behavior:
+        // - fade stiffness/feed-forward near target so damping can dissipate residual energy
+        // - low-pass omega/alpha to avoid exciting high-frequency solver jitter
+        // - per-tick omega-step clamp keeps discrete-time response stable at high strength/inertia
+        private const val SERVO_PHYS_TICK_DT_SEC = 1.0 / 20.0
+        private const val SERVO_HOLD_BLEND_ERROR_RAD = 0.004
+        private const val SERVO_HOLD_RELEASE_ERROR_RAD = 0.03
+        private const val SERVO_OMEGA_FILTER_ALPHA_NEAR_HOLD = 0.45
+        private const val SERVO_OMEGA_FILTER_ALPHA_ACTIVE = 0.80
+        private const val SERVO_ALPHA_FILTER_ALPHA_NEAR_HOLD = 0.75
+        private const val SERVO_ALPHA_FILTER_ALPHA_ACTIVE = 0.95
+        private const val SERVO_HOLD_MAX_OMEGA_STEP_PER_TICK = 0.30
+        private const val SERVO_ACTIVE_MAX_OMEGA_STEP_PER_TICK = 1.6
+
+        // Hinge-axis explicit damping: tau_damp = -c * omega (c = I_eff * damping_rate).
+        // Applied in LOCKED/aligning or when close to target with near-zero command.
+        private const val SERVO_DAMPING_NEAR_TARGET_ERROR_RAD = 0.03
+        private const val SERVO_DAMPING_HOLD_CMD_OMEGA_RAD_SEC = 0.20
+        private const val SERVO_DAMPING_MIN_ACTIVE_OMEGA_RAD_SEC = 0.03
+        private const val SERVO_HINGE_DAMPING_RATE_LOCKED = 1.4
+        private const val SERVO_HINGE_DAMPING_RATE_NEAR_TARGET = 1.0
+        private const val SERVO_HINGE_DAMPING_MAX_TORQUE_FRACTION = 0.12
+        private const val SERVO_HINGE_DAMPING_MAX_ALPHA_EQUIV = 8.0
+
+        // FOLLOW_ANGLE feed-forward safety: fade and zero FF near target to avoid hunting.
+        private const val FOLLOW_FF_FADE_START_ERROR_RAD = 0.02
+        private const val FOLLOW_FF_FADE_END_ERROR_RAD = 0.18
+        private const val FOLLOW_FF_ZERO_ERROR_RAD = 0.03
+        private const val FOLLOW_FF_ZERO_OMEGA_RAD_SEC = 0.10
+
+        // Off-axis anchor seating (perpendicular to hinge axis) to suppress lateral wobble under heavy load.
+        // Shared strength slider maps both seat stiffness and seat force limit.
+        private const val SERVO_SEAT_DAMPING_RATIO_MIN = 1.4
+        private const val SERVO_SEAT_DAMPING_RATIO_MAX = 2.8
+        private const val SERVO_SEAT_WN_MIN = 2.0
+        private const val SERVO_SEAT_WN_MAX = 20.0
+        private const val SERVO_SEAT_MAX_ERROR_M = 0.35
+        private const val SERVO_SEAT_MAX_ACCEL_HARD = 40.0 // m/s^2 hard stability clamp
+        private const val SERVO_SEAT_MAX_ACCEL_WORLD_ANCHOR = 8.0
+        private const val SERVO_SEAT_WORLD_ANCHOR_KP_SCALE = 0.35
+        private const val SERVO_SEAT_WORLD_ANCHOR_KD_SCALE = 0.65
+        private const val SERVO_SEAT_ERROR_DEADBAND_M = 1.0e-3
+        private const val SERVO_SEAT_VEL_DEADBAND = 0.02
+        private const val SERVO_SEAT_FORCE_LIMIT_MIN = 5.0e5
+        private const val SERVO_SEAT_FORCE_LIMIT_MAX = 2.0e10
+
+        // Off-axis angular swing lock (suppresses metronome-like side swing in bearing chains).
+        private const val SERVO_TILT_OMEGA_DEADBAND = 2.0e-3 // rad/s
+        private const val SERVO_TILT_DAMPING_RATIO_MIN = 1.8
+        private const val SERVO_TILT_DAMPING_RATIO_MAX = 3.0
+        private const val SERVO_TILT_WN_MIN = 6.0
+        private const val SERVO_TILT_WN_MAX = 60.0
+        private const val SERVO_TILT_MAX_ERROR_RAD = 0.4
+        private const val SERVO_TILT_DAMP_ONLY_ERROR_RAD = 0.01
+        private const val SERVO_TILT_FULL_STIFFNESS_ERROR_RAD = 0.12
+        private const val SERVO_TILT_WORLD_ANCHOR_WN_SCALE = 0.35
+        private const val SERVO_TILT_MAX_ALPHA_WORLD_ANCHOR = 20.0
+        private const val SERVO_TILT_MAX_ALPHA_HARD = 200.0 // rad/s^2 hard stability clamp
+        private const val SERVO_TILT_MAX_ALPHA_EQUIV = 12.0
+        private const val SERVO_TILT_MAX_ALPHA_EQUIV_WORLD_ANCHOR = 4.0
+        private const val SERVO_TILT_TORQUE_MIN = 1.0e6
+        private const val SERVO_TILT_TORQUE_MAX = 5.0e11
+
+        // Joint constraint strength (keeps the bearing locked into the rotation plane).
+        private const val SERVO_JOINT_MAX_FORCE = 1.0e10f
+        private const val SERVO_JOINT_ANCHOR_OFFSET = 1.0
+
+        // Gentle re-anchoring to correct accumulated joint drift (does not retarget angle/pose each tick).
+        private const val SERVO_REANCHOR_PERIOD_TICKS = 30
+        private const val SERVO_REANCHOR_POS_EPS = 0.12
+        private const val SERVO_REANCHOR_MAX_STEP = 0.03
+        private const val SERVO_REANCHOR_MAX_HINGE_OMEGA_RAD_SEC = 0.25
+        private const val SERVO_REANCHOR_MAX_REL_VEL_MPS = 0.12
+        private const val SERVO_REANCHOR_MIN_MOTION_SCALE = 0.20
+        private const val SERVO_REANCHOR_MIN_STEP = 0.003
 
         // Extremely stiff, but not pathological (avoid ~1e-100 which can blow up solvers).
         private const val SERVO_COMPLIANCE = 1.0e-10

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -231,11 +231,12 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val stiffnessT = servoStiffnessSetting.toDouble() / SERVO_STIFFNESS_MAX.toDouble()
 
         val wn = lerpLog(SERVO_WN_MIN, SERVO_WN_MAX, stiffnessT.coerceIn(0.0, 1.0))
-        servoKp = wn * wn
-        servoKd = 2.0 * SERVO_DAMPING_RATIO * wn
+        val testScale = SERVO_TEST_SCALE
+        servoKp = wn * wn * testScale
+        servoKd = 2.0 * SERVO_DAMPING_RATIO * wn * testScale
 
-        servoMaxAlpha = lerpLog(SERVO_ALPHA_MIN, SERVO_ALPHA_MAX, strengthT.coerceIn(0.0, 1.0))
-        servoTorqueLimit = lerpLog(SERVO_FORCE_TORQUE_MIN, SERVO_FORCE_TORQUE_MAX, strengthT.coerceIn(0.0, 1.0))
+        servoMaxAlpha = lerpLog(SERVO_ALPHA_MIN, SERVO_ALPHA_MAX, strengthT.coerceIn(0.0, 1.0)) * testScale
+        servoTorqueLimit = lerpLog(SERVO_FORCE_TORQUE_MIN, SERVO_FORCE_TORQUE_MAX, strengthT.coerceIn(0.0, 1.0)) * testScale
     }
 
     private fun updateDrive() {
@@ -1208,6 +1209,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         // - "Stiffness" controls closed-loop natural frequency (wn), with Kp = wn^2.
         // - Kd is chosen for a fixed damping ratio to minimize sway/overshoot.
         // - "Strength" caps both max torque and max angular acceleration.
+        // Temporary: boost slider magnitudes for testing (e.g., UI 100 behaves like 1000).
+        private const val SERVO_TEST_SCALE = 1.0
         private const val SERVO_DAMPING_RATIO = 1.25
         private const val SERVO_WN_MIN = 4.0
         private const val SERVO_WN_MAX = 64.0

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -1,5 +1,6 @@
 package org.valkyrienskies.clockwork.content.contraptions.phys.bearing
 
+import com.mojang.blaze3d.vertex.PoseStack
 import com.simibubi.create.AllSoundEvents
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity
 import com.simibubi.create.content.contraptions.AssemblyException
@@ -9,21 +10,28 @@ import com.simibubi.create.content.contraptions.bearing.BearingBlock
 import com.simibubi.create.content.contraptions.bearing.IBearingBlockEntity
 import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity
 import com.simibubi.create.content.kinetics.transmission.sequencer.SequencerInstructions
+import com.simibubi.create.foundation.blockEntity.behaviour.BehaviourType
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
+import com.simibubi.create.foundation.blockEntity.behaviour.ValueBoxTransform
 import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollOptionBehaviour
+import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollValueBehaviour
 import com.simibubi.create.foundation.item.TooltipHelper
 import com.simibubi.create.foundation.utility.ServerSpeedProvider
+import dev.engine_room.flywheel.lib.transform.TransformStack
 import net.createmod.catnip.math.AngleHelper
+import net.createmod.catnip.math.VecHelper
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.chat.Component
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.util.Mth
+import net.minecraft.world.level.LevelAccessor
 import net.minecraft.world.level.ClipContext
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.phys.Vec3
 import org.joml.*
 import org.valkyrienskies.clockwork.ClockworkMod
 import org.valkyrienskies.clockwork.ClockworkMod.MOD_ID
@@ -126,12 +134,25 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     @Volatile private var lockedHoldAngleRad: Double? = null
     @Volatile private var followOmegaFeedForwardRadSec: Double = 0.0
 
+    private var servoStrengthBehaviour: ServoStrengthScrollValueBehaviour? = null
+    private var servoStiffnessBehaviour: ServoStiffnessScrollValueBehaviour? = null
+
+    @Volatile private var servoStrengthSetting: Int = SERVO_STRENGTH_DEFAULT
+    @Volatile private var servoStiffnessSetting: Int = SERVO_STIFFNESS_DEFAULT
+
+    // Derived (phys-thread) servo parameters.
+    @Volatile private var servoKp: Double = SERVO_KP
+    @Volatile private var servoKd: Double = SERVO_KD
+    @Volatile private var servoMaxAlpha: Double = SERVO_MAX_ALPHA
+    @Volatile private var servoTorqueLimit: Double = SERVO_MAX_TORQUE.toDouble()
+
     private var controllerCreationData: PhysBearingData? = null
     private var controllerUpdateData: PhysBearingUpdateData? = null
     private var loadingFn: ((ServerLevel) -> Unit)? = null
 
     init {
         setLazyTickRate(3)
+        recomputeServoTuning()
     }
 
     private fun movementModeChanged(value: Int) {
@@ -150,6 +171,71 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         movementMode!!.withCallback{movementModeChanged(it)}
         movementMode!!.requiresWrench()
         behaviours.add(movementMode!!)
+
+        servoStrengthBehaviour = ServoStrengthScrollValueBehaviour(
+            Component.translatable("$MOD_ID.phys_bearing.servo_strength"),
+            this,
+            ServoSettingValueBoxTransform(8.0, 4.0)
+        ).also {
+            it.between(SERVO_STRENGTH_MIN, SERVO_STRENGTH_MAX)
+            it.currentValue = servoStrengthSetting
+            it.withCallback { v -> setServoStrengthSetting(v, sendUpdate = true) }
+            it.requiresWrench()
+            behaviours.add(it)
+        }
+
+        servoStiffnessBehaviour = ServoStiffnessScrollValueBehaviour(
+            Component.translatable("$MOD_ID.phys_bearing.servo_stiffness"),
+            this,
+            ServoSettingValueBoxTransform(8.0, 12.0)
+        ).also {
+            it.between(SERVO_STIFFNESS_MIN, SERVO_STIFFNESS_MAX)
+            it.currentValue = servoStiffnessSetting
+            it.withCallback { v -> setServoStiffnessSetting(v, sendUpdate = true) }
+            it.requiresWrench()
+            behaviours.add(it)
+        }
+    }
+
+    private fun setServoStrengthSetting(value: Int, sendUpdate: Boolean) {
+        val clamped = value.coerceIn(SERVO_STRENGTH_MIN, SERVO_STRENGTH_MAX)
+        if (servoStrengthSetting == clamped) return
+        servoStrengthSetting = clamped
+        recomputeServoTuning()
+        if (sendUpdate && level != null && !level!!.isClientSide) {
+            updateDrive()
+            sendData()
+        }
+    }
+
+    private fun setServoStiffnessSetting(value: Int, sendUpdate: Boolean) {
+        val clamped = value.coerceIn(SERVO_STIFFNESS_MIN, SERVO_STIFFNESS_MAX)
+        if (servoStiffnessSetting == clamped) return
+        servoStiffnessSetting = clamped
+        recomputeServoTuning()
+        if (sendUpdate && level != null && !level!!.isClientSide) {
+            updateDrive()
+            sendData()
+        }
+    }
+
+    private fun lerpLog(min: Double, max: Double, t: Double): Double {
+        if (min <= 0.0 || max <= 0.0) return min + (max - min) * t
+        val lnMin = ln(min)
+        val lnMax = ln(max)
+        return exp(lnMin + (lnMax - lnMin) * t)
+    }
+
+    private fun recomputeServoTuning() {
+        val strengthT = servoStrengthSetting.toDouble() / SERVO_STRENGTH_MAX.toDouble()
+        val stiffnessT = servoStiffnessSetting.toDouble() / SERVO_STIFFNESS_MAX.toDouble()
+
+        val wn = lerpLog(SERVO_WN_MIN, SERVO_WN_MAX, stiffnessT.coerceIn(0.0, 1.0))
+        servoKp = wn * wn
+        servoKd = 2.0 * SERVO_DAMPING_RATIO * wn
+
+        servoMaxAlpha = lerpLog(SERVO_ALPHA_MIN, SERVO_ALPHA_MAX, strengthT.coerceIn(0.0, 1.0))
+        servoTorqueLimit = lerpLog(SERVO_FORCE_TORQUE_MIN, SERVO_FORCE_TORQUE_MAX, strengthT.coerceIn(0.0, 1.0))
     }
 
     private fun updateDrive() {
@@ -288,8 +374,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
         val omegaErr = omegaFf - omegaActual
         val errorForControl = errorRad.coerceIn(-SERVO_MAX_ERROR_RAD, SERVO_MAX_ERROR_RAD)
-        var alphaCmd = SERVO_KP * errorForControl + SERVO_KD * omegaErr
-        alphaCmd = alphaCmd.coerceIn(-SERVO_MAX_ALPHA, SERVO_MAX_ALPHA)
+        var alphaCmd = servoKp * errorForControl + servoKd * omegaErr
+        alphaCmd = alphaCmd.coerceIn(-servoMaxAlpha, servoMaxAlpha)
 
         // Ensure the joint isn't treated as free-spin in servo modes. We do NOT rely on the joint motor here because
         // it's backend-dependent; instead we apply an explicit torque servo below.
@@ -324,7 +410,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         // Torque = I_eff * alpha_cmd, clamped.
         var torqueMag = torqueMassMultiplier * alphaCmd
-        val maxTorque = SERVO_MAX_TORQUE.toDouble()
+        val maxTorque = servoTorqueLimit
         torqueMag = torqueMag.coerceIn(-maxTorque, maxTorque)
 
         val torqueVec = axisWorld.mul(torqueMag, Vector3d())
@@ -472,6 +558,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
 
         super.read(tag, clientPacket)
+        // Behaviours were just read; sync derived servo parameters from the persisted values.
+        servoStrengthBehaviour?.also { setServoStrengthSetting(it.currentValue, sendUpdate = false) }
+        servoStiffnessBehaviour?.also { setServoStiffnessSetting(it.currentValue, sendUpdate = false) }
         if (clientPacket) {return}
 
         // may not have level on read so i have to do this
@@ -1013,8 +1102,119 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     override fun getBlockPosition(): BlockPos = worldPosition
     override fun isWoodenTop(): Boolean = false
 
+    private class ServoSettingValueBoxTransform(private val y: Double, private val x: Double) : ValueBoxTransform.Sided() {
+        override fun getSouthLocation(): Vec3 {
+            return VecHelper.voxelSpace(x, y, 15.5)
+        }
+
+        override fun getLocalOffset(level: LevelAccessor, pos: BlockPos, state: BlockState): Vec3 {
+            return super.getLocalOffset(level, pos, state)
+                .add(
+                    Vec3.atLowerCornerOf(state.getValue(BearingBlock.FACING).normal)
+                        .scale((-2 / 16f).toDouble())
+                )
+        }
+
+        override fun rotate(level: LevelAccessor, pos: BlockPos, state: BlockState, ms: PoseStack) {
+            if (!side.axis.isHorizontal) {
+                TransformStack.of(ms)
+                    .rotateYDegrees((AngleHelper.horizontalAngle(state.getValue(BearingBlock.FACING)) + 180))
+            }
+            super.rotate(level, pos, state, ms)
+        }
+
+        override fun isSideActive(state: BlockState, direction: Direction): Boolean {
+            // Match Create's bearing mode selector faces: show on the 4 side faces around the bearing axis.
+            return direction.axis != state.getValue(BearingBlock.FACING).axis
+        }
+    }
+
+    private open class ServoTuningScrollValueBehaviour(
+        label: Component,
+        be: GeneratingKineticBlockEntity,
+        slot: ValueBoxTransform,
+        private val behaviourNetId: Int
+    ) : ScrollValueBehaviour(label, be, slot) {
+        // ScrollValueBehaviour.value is protected; expose it for BE init/sync.
+        var currentValue: Int
+            get() = value
+            set(v) { value = v }
+
+        override fun netId(): Int = behaviourNetId
+    }
+
+    private class ServoStrengthScrollValueBehaviour(
+        label: Component,
+        be: GeneratingKineticBlockEntity,
+        slot: ValueBoxTransform
+    ) : ServoTuningScrollValueBehaviour(label, be, slot, 1) {
+
+        override fun getType(): BehaviourType<*> = TYPE
+
+        override fun getClipboardKey(): String = "PhysBearingServoStrength"
+
+        override fun write(nbt: CompoundTag, clientPacket: Boolean) {
+            nbt.putInt(NBT_KEY, currentValue)
+        }
+
+        override fun read(nbt: CompoundTag, clientPacket: Boolean) {
+            if (nbt.contains(NBT_KEY)) currentValue = nbt.getInt(NBT_KEY)
+        }
+
+        companion object {
+            val TYPE: BehaviourType<ServoStrengthScrollValueBehaviour> =
+                BehaviourType("phys_bearing_servo_strength")
+            private const val NBT_KEY = "ServoStrength"
+        }
+    }
+
+    private class ServoStiffnessScrollValueBehaviour(
+        label: Component,
+        be: GeneratingKineticBlockEntity,
+        slot: ValueBoxTransform
+    ) : ServoTuningScrollValueBehaviour(label, be, slot, 2) {
+
+        override fun getType(): BehaviourType<*> = TYPE
+
+        override fun getClipboardKey(): String = "PhysBearingServoStiffness"
+
+        override fun write(nbt: CompoundTag, clientPacket: Boolean) {
+            nbt.putInt(NBT_KEY, currentValue)
+        }
+
+        override fun read(nbt: CompoundTag, clientPacket: Boolean) {
+            if (nbt.contains(NBT_KEY)) currentValue = nbt.getInt(NBT_KEY)
+        }
+
+        companion object {
+            val TYPE: BehaviourType<ServoStiffnessScrollValueBehaviour> =
+                BehaviourType("phys_bearing_servo_stiffness")
+            private const val NBT_KEY = "ServoStiffness"
+        }
+    }
+
     companion object {
         const val NO_SHIPTRAPTION_ID: Long = -1
+
+        // Per-bearing tuning UI (Create value boxes).
+        private const val SERVO_STRENGTH_MIN = 0
+        private const val SERVO_STRENGTH_MAX = 100
+        private const val SERVO_STRENGTH_DEFAULT = 50
+        private const val SERVO_STIFFNESS_MIN = 0
+        private const val SERVO_STIFFNESS_MAX = 100
+        private const val SERVO_STIFFNESS_DEFAULT = 50
+
+        // Slider mapping:
+        // - "Stiffness" controls closed-loop natural frequency (wn), with Kp = wn^2.
+        // - Kd is chosen for a fixed damping ratio to minimize sway/overshoot.
+        // - "Strength" caps both max torque and max angular acceleration.
+        private const val SERVO_DAMPING_RATIO = 1.25
+        private const val SERVO_WN_MIN = 4.0
+        private const val SERVO_WN_MAX = 64.0
+        private const val SERVO_ALPHA_MIN = 30.0
+        private const val SERVO_ALPHA_MAX = 480.0
+        private const val SERVO_FORCE_TORQUE_MIN = 1.0e8
+        private const val SERVO_FORCE_TORQUE_MAX = 1.0e10
 
         // Servo tuning (acceleration-space PD):
         //   alpha_cmd = Kp * angle_error + Kd * (omega_target - omega_actual)

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -70,26 +70,6 @@ import org.valkyrienskies.mod.util.putVector3d
 import java.lang.Math
 import kotlin.math.*
 
-//TODO move
-fun getHingeRotation(localDir: Vector3dc, right: Vector3dc = Vector3d(1.0, 0.0, 0.0)): Quaterniond {
-    if ((localDir - right).length() < 1e-5) { return Quaterniond() }
-
-    val v1l = right.length()
-    val v2l = localDir.length()
-
-    val a = right.cross(localDir, Vector3d())
-
-    val k = sqrt(v1l * v1l * v2l * v2l)
-    val kCosTheta = right.dot(localDir)
-
-    if (abs(kCosTheta / k + 1.0) < 1e-5) {
-        val ort = right.let { it.orthogonalize(it, Vector3d()) }
-        return Quaterniond(ort.x, ort.y, ort.z, 0.0).normalize()
-    }
-
-    return Quaterniond(a.x, a.y, a.z, k + kCosTheta).normalize()
-}
-
 class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: BlockState?) :
     GeneratingKineticBlockEntity(type, pos, state), IBearingBlockEntity, IDisplayAssemblyExceptions,
     ContraptionController, BlockEntityPhysicsListener {
@@ -100,7 +80,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private set
     var shiptraptionID = NO_SHIPTRAPTION_ID
         private set
-    var targetAngle = 0f
+    @Volatile var targetAngle = 0f
         get() = field
         private set(idk) {field = idk}
     var disassembleWhenPossible = false
@@ -133,12 +113,18 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
     //pos of bearing in subship coordinates
     private var bearingPos: Vector3d = Vector3d()
-    private var aligning = false
+    @Volatile private var aligning = false
     private var bearingAxis: Vector3d = Vector3d()
     private var bearingID: Int = -1
 
     private var lastSpeed = 0f
     private var lastMode = LockedMode.UNLOCKED
+    private var lastAligningState = false
+
+    // Phys-thread reads these; game-thread writes them.
+    @Volatile private var servoMode: LockedMode = LockedMode.UNLOCKED
+    @Volatile private var lockedHoldAngleRad: Double? = null
+    @Volatile private var followOmegaFeedForwardRadSec: Double = 0.0
 
     private var controllerCreationData: PhysBearingData? = null
     private var controllerUpdateData: PhysBearingUpdateData? = null
@@ -150,6 +136,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
     private fun movementModeChanged(value: Int) {
         if (level == null || level!!.isClientSide) {return}
+        // Immediately switch joint behavior when the player changes modes.
+        tryUpdateData()
         sendData()
     }
 
@@ -164,71 +152,188 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         behaviours.add(movementMode!!)
     }
 
-    private fun updateDrive(driveVelocity: VSRevoluteJoint.VSRevoluteDriveVelocity? = null) {
-        if (movementMode!!.get() == LockedMode.FOLLOW_ANGLE || aligning) {
-            joint = VSFixedJoint(joint!!.shipId0, joint!!.pose0, joint!!.shipId1, joint!!.pose1, compliance = 1e-100)
-            controllerUpdateData = PhysBearingUpdateData(
-                Math.toRadians(targetAngle.toDouble()),
-                0f,
-                false
+    private fun updateDrive() {
+        val level = level as? ServerLevel ?: return
+        val existing = joint ?: return
+        val mode = movementMode?.get() ?: LockedMode.UNLOCKED
+
+        // Keep the joint REVOLUTE in all modes; servo is implemented via driveVelocity in physTick.
+        val revolute = when (existing) {
+            is VSRevoluteJoint -> existing
+            is VSFixedJoint -> VSRevoluteJoint(
+                existing.shipId0, existing.pose0, existing.shipId1, existing.pose1,
+                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                compliance = SERVO_COMPLIANCE,
+                driveFreeSpin = true
+            )
+            else -> return
+        }
+
+        val servoActive = aligning || mode != LockedMode.UNLOCKED
+        val baseJoint = if (servoActive) {
+            revolute.copy(
+                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                compliance = SERVO_COMPLIANCE,
+                // We don't rely on the revolute motor for servo behavior; see physTick torque servo.
+                driveVelocity = null,
+                driveForceLimit = null,
+                driveGearRatio = null,
+                driveFreeSpin = false
             )
         } else {
-            joint = VSRevoluteJoint(joint!!.shipId0, joint!!.pose0, joint!!.shipId1, joint!!.pose1, compliance = 1e-100, driveFreeSpin = true)
-            controllerUpdateData = PhysBearingUpdateData(
-                Math.toRadians(targetAngle.toDouble()),
-                getRealisticAngularSpeed(),
-                false
+            revolute.copy(
+                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                compliance = SERVO_COMPLIANCE,
+                driveVelocity = null,
+                driveForceLimit = null,
+                driveFreeSpin = true
             )
-            (level as ServerLevel).gtpa.updateJoint(jointID, joint!!)
+        }
+
+        joint = baseJoint
+        servoMode = mode
+        // Sign matches tick() targetAngle integration and BearingController's ideal omega convention.
+        followOmegaFeedForwardRadSec = if (!aligning && mode == LockedMode.FOLLOW_ANGLE) -getRealisticAngularSpeed().toDouble() else 0.0
+
+        controllerUpdateData = PhysBearingUpdateData(
+            Math.toRadians(targetAngle.toDouble()),
+            if (mode == LockedMode.UNLOCKED && !aligning) getRealisticAngularSpeed() else 0f,
+            servoActive
+        )
+
+        if (jointID != -1) {
+            level.gtpa.updateJoint(jointID, baseJoint)
         }
     }
 
     @Volatile override lateinit var dimension: DimensionId
-    @Volatile private var sDir1: Vector3dc? = null
-    @Volatile private var sDir2: Vector3dc? = null
-    @Volatile private var pTick = 0
     @Volatile private var lastAngle = targetAngle
     @Volatile private var curAngle = targetAngle
+
+    private fun shortestAngleErrorRad(target: Double, current: Double): Double {
+        // Returns error in (-pi, pi].
+        val d = target - current
+        return atan2(sin(d), cos(d))
+    }
+
+    private fun getAngularInertia(physShip: PhysShip, localPos: Vector3dc, axisGlobal: Vector3dc): Double {
+        val globalPos: Vector3dc = physShip.transform.shipToWorld.transformPosition(localPos, Vector3d())
+        val offset: Vector3dc = globalPos.sub(physShip.transform.positionInWorld, Vector3d())
+        return getAngularInertia(
+            physShip.momentOfInertia,
+            physShip.transform.shipToWorldRotation,
+            physShip.mass,
+            offset,
+            axisGlobal
+        )
+    }
+
+    private fun getAngularInertia(
+        inertiaTensorLocal: Matrix3dc,
+        rotation: Quaterniondc,
+        mass: Double,
+        offsetGlobal: Vector3dc,
+        axisGlobal: Vector3dc
+    ): Double {
+        val offsetPerpToAxis: Vector3dc =
+            offsetGlobal.sub(axisGlobal.mul(axisGlobal.dot(offsetGlobal), Vector3d()), Vector3d())
+        val axisLocal: Vector3dc = rotation.transformInverse(axisGlobal, Vector3d())
+        return inertiaTensorLocal.transform(axisLocal, Vector3d())
+            .dot(axisLocal) + offsetPerpToAxis.lengthSquared() * mass
+    }
+
+    private fun parallelOperator(left: Double, right: Double): Double {
+        return 1.0 / (1.0 / left + 1.0 / right)
+    }
+
     override fun physTick(physShip: PhysShip?, physLevel: PhysLevel) {
         if (isRemoved || !isRunning) return
-        if (jointID == -1) return
-        val joint = joint as? VSFixedJoint ?: return
+        val jointId = jointID
+        if (jointId == -1) return
 
-        if (curAngle != targetAngle) {
-            pTick = 0
-            lastAngle = curAngle
-            curAngle = targetAngle
+        val revolute = joint as? VSRevoluteJoint ?: return
+        val mode = servoMode
+        val servoActive = aligning || mode != LockedMode.UNLOCKED
+        if (!servoActive) return
+
+        // We need both transforms to compute angle; if ships aren't loaded yet, just wait.
+        val subShip = revolute.shipId0?.let { physLevel.getShipById(it) } ?: run {
+            if (DEBUG_SERVO) ClockworkMod.LOGGER.info("[PhysBearing] physTick: subShip not loaded yet (jointId={}, ship0={})", jointId, revolute.shipId0)
+            return
+        }
+        val mainShip = revolute.shipId1?.let { physLevel.getShipById(it) }
+
+        val currentAngleRad = getAngle(bearingAxis, subShip.transform, mainShip?.transform)
+        val targetAngleRad = when {
+            aligning -> 0.0
+            mode == LockedMode.LOCKED -> lockedHoldAngleRad ?: currentAngleRad.also { lockedHoldAngleRad = it }
+            else -> Math.toRadians(targetAngle.toDouble())
         }
 
-        var angle = Math.toRadians(lastAngle + (targetAngle - lastAngle) * ((pTick+1) / 3.0))
-        if (aligning) { angle = 0.0 }
+        var errorRad = shortestAngleErrorRad(targetAngleRad, currentAngleRad)
+        if (abs(errorRad) < SERVO_DEADBAND_RAD) errorRad = 0.0
+        val axisWorld = bearingAxis.get(Vector3d())
+        mainShip?.transform?.shipToWorldRotation?.transform(axisWorld)
 
-        physLevel as VsiPhysLevel
-        if (sDir1 == null || sDir2 == null) {
-            sDir1 = bearingAxis
-            sDir2 = bearingAxis
+        val relOmegaWorld = Vector3d(subShip.angularVelocity)
+        if (mainShip != null) relOmegaWorld.sub(mainShip.angularVelocity)
+        val omegaActual = relOmegaWorld.dot(axisWorld) // rad/s along the bearing axis
+
+        // FOLLOW_ANGLE should respond immediately to kinetic input; use a feed-forward target omega and a PD in
+        // acceleration-space. This avoids the "infinite torque" behavior that destabilizes heavy/offset ships.
+        val omegaFf = if (!aligning && mode == LockedMode.FOLLOW_ANGLE) {
+            followOmegaFeedForwardRadSec.coerceIn(-SERVO_MAX_OMEGA, SERVO_MAX_OMEGA)
+        } else {
+            0.0
         }
+        val omegaErr = omegaFf - omegaActual
+        val errorForControl = errorRad.coerceIn(-SERVO_MAX_ERROR_RAD, SERVO_MAX_ERROR_RAD)
+        var alphaCmd = SERVO_KP * errorForControl + SERVO_KD * omegaErr
+        alphaCmd = alphaCmd.coerceIn(-SERVO_MAX_ALPHA, SERVO_MAX_ALPHA)
 
-        //AxisAngle4d clamps angle, so when going from 359 to 0 degrees quat jumps from -0.999 w to 0.999 w or smth like that
-        // which causes krunch to incorrectly interpolate, so i just extend angle range to [0, 720) and manually do this shit
-        val s = sin(angle * 0.5)
-        val fRot2 = Quaterniond(
-            sDir1!!.x() * s,
-            sDir1!!.y() * s,
-            sDir1!!.z() * s,
-            org.joml.Math.cosFromSin(s, angle * 0.5)
-        ).mul(getHingeRotation(sDir1!!))
-        val fRot1 = getHingeRotation(sDir2!!)
-
-        this.joint = VSFixedJoint(
-            joint.shipId0, VSJointPose(joint.pose0.pos, fRot1),
-            joint.shipId1, VSJointPose(joint.pose1.pos, fRot2),
-            compliance = 1e-100
+        // Ensure the joint isn't treated as free-spin in servo modes. We do NOT rely on the joint motor here because
+        // it's backend-dependent; instead we apply an explicit torque servo below.
+        val updated = revolute.copy(
+            maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+            compliance = SERVO_COMPLIANCE,
+            driveVelocity = null,
+            driveForceLimit = null,
+            driveGearRatio = null,
+            driveFreeSpin = false
         )
+        if (updated != revolute) {
+            joint = updated
+            (physLevel as? VsiPhysLevel)?.updateJoint(jointId, updated)
+        }
 
-        physLevel.updateJoint(jointID, this.joint!!)
+        // Torque servo (works even when revolute drive velocity is not honored).
+        val torqueMassMultiplier: Double = run {
+            val canSub = !subShip.isStatic
+            val canMain = mainShip != null && !mainShip.isStatic
+            if (!canSub && !canMain) return
 
-        pTick = max(pTick++, 2)
+            val subInertia = if (canSub) getAngularInertia(subShip, updated.pose0.pos, axisWorld) else 0.0
+            val mainInertia = if (canMain) getAngularInertia(mainShip!!, updated.pose1.pos, axisWorld) else 0.0
+
+            when {
+                canSub && canMain -> parallelOperator(subInertia, mainInertia)
+                canSub -> subInertia
+                else -> mainInertia
+            }
+        }
+
+        // Torque = I_eff * alpha_cmd, clamped.
+        var torqueMag = torqueMassMultiplier * alphaCmd
+        val maxTorque = SERVO_MAX_TORQUE.toDouble()
+        torqueMag = torqueMag.coerceIn(-maxTorque, maxTorque)
+
+        val torqueVec = axisWorld.mul(torqueMag, Vector3d())
+        if (!subShip.isStatic) {
+            subShip.applyWorldTorque(torqueVec)
+        }
+        if (mainShip != null && !mainShip.isStatic) {
+            mainShip.applyWorldTorque(torqueVec.mul(-1.0, Vector3d()))
+        }
     }
 
     public override fun write(tag: CompoundTag, clientPacket: Boolean) {
@@ -252,9 +357,10 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         tag.putBoolean("aligning", aligning)
 
         val mapper = VSJacksonUtil.dtoMapper
-        when (joint) {
-            is VSRevoluteJoint -> tag.putByteArray("joint", mapper.writeValueAsBytes(joint!!))
-            is VSFixedJoint -> tag.putByteArray("fjoint", mapper.writeValueAsBytes(joint!!))
+        // Avoid saving a potentially large/non-zero drive velocity from mid-servo movement.
+        val jointForSave = (joint as? VSRevoluteJoint)?.copy(driveVelocity = null) ?: joint
+        if (jointForSave is VSRevoluteJoint) {
+            tag.putByteArray("joint", mapper.writeValueAsBytes(jointForSave))
         }
 
         tag.putInt("jointID", jointID)
@@ -268,7 +374,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     }
 
     private fun loadTheRest(tag: CompoundTag, level: ServerLevel) {
-        var joint = this.joint ?: return
+        val joint = this.joint ?: return
         val mainId = level.getShipManagingPos(worldPosition)?.id
 
         val oldBPos = BlockPos.of(tag.getLong(ClockworkConstants.Nbt.OLD_POS))
@@ -281,21 +387,31 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         bearingPos = bearingPos.sub(oldSPos).add(newSPos)
 
-        this.joint = when(joint) {
-            is VSRevoluteJoint -> joint.copy(
-                shiptraptionID, pose0 = VSJointPose(joint.pose0.pos - oldSPos + newSPos, joint.pose0.rot),
-                mainId,         pose1 = VSJointPose(joint.pose1.pos - oldPos  + newPos,  joint.pose1.rot))
-            is VSFixedJoint -> joint.copy(
-                shiptraptionID, pose0 = VSJointPose(joint.pose0.pos - oldSPos + newSPos, joint.pose0.rot),
-                mainId,         pose1 = VSJointPose(joint.pose1.pos - oldPos  + newPos,  joint.pose1.rot))
+        // Worlds may contain legacy fixed-joint NBT. Always convert to a revolute joint on load.
+        val revolute = when (joint) {
+            is VSRevoluteJoint -> joint
+            is VSFixedJoint -> VSRevoluteJoint(
+                joint.shipId0, joint.pose0, joint.shipId1, joint.pose1,
+                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                compliance = SERVO_COMPLIANCE,
+                driveFreeSpin = true
+            )
             else -> throw AssertionError()
         }
+
+        this.joint = revolute.copy(
+            shipId0 = shiptraptionID,
+            pose0 = VSJointPose(revolute.pose0.pos - oldSPos + newSPos, revolute.pose0.rot),
+            shipId1 = mainId,
+            pose1 = VSJointPose(revolute.pose1.pos - oldPos + newPos, revolute.pose1.rot),
+            driveVelocity = null, // start neutral; physTick will apply servo if needed
+        )
 
         controllerCreationData = PhysBearingData(
             bearingAxis.get(Vector3d()),
             Math.toRadians(targetAngle.toDouble()),
             getRealisticAngularSpeed(),
-            movementMode!!.get() == LockedMode.FOLLOW_ANGLE,
+            (movementMode?.get() ?: LockedMode.UNLOCKED) != LockedMode.UNLOCKED,
             aligning,
             mainId ?: -1L,
             this.joint?.pose1?.pos?.get(Vector3d()) ?: Vector3d(),
@@ -341,10 +457,17 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             joint = temp.joint as VSRevoluteJoint
             jointID = temp.jointId
         } else if (tag.contains("joint")) {
-            joint = mapper.readValue(tag.getByteArray("joint"), VSRevoluteJoint::class.java)
+            joint = mapper.readValue(tag.getByteArray("joint"), VSRevoluteJoint::class.java).copy(driveVelocity = null)
             jointID = tag.getInt("jointID")
         } else if (tag.contains("fjoint")) {
-            joint = mapper.readValue(tag.getByteArray("fjoint"), VSFixedJoint::class.java)
+            // Legacy worlds: fixed-joint FOLLOW_ANGLE implementation. Convert immediately to revolute.
+            val fj = mapper.readValue(tag.getByteArray("fjoint"), VSFixedJoint::class.java)
+            joint = VSRevoluteJoint(
+                fj.shipId0, fj.pose0, fj.shipId1, fj.pose1,
+                maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+                compliance = SERVO_COMPLIANCE,
+                driveFreeSpin = true
+            )
             jointID = tag.getInt("jointID")
         }
 
@@ -388,6 +511,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
     val angularSpeed: Float
         get() {
+            val mode = movementMode?.get() ?: LockedMode.UNLOCKED
+            if (aligning || mode == LockedMode.LOCKED) return 0f
             var speed = convertToAngular(getSpeed())
             if (getSpeed() == 0f) speed = 0f
             if (level!!.isClientSide) {
@@ -450,17 +575,28 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         ClockworkMod.physTickOnce(level.dimensionId!!) { level, _, tryNextTick ->
             level as VsiPhysLevel
-            val existing = level.getJointById(jointID)
-            if (existing != null && existing == joint) {
-                isRunning = true
-                return@physTickOnce
-            }
             if (
                 joint.shipId0 != null && level.getShipById(joint.shipId0!!) == null ||
                 joint.shipId1 != null && level.getShipById(joint.shipId1!!) == null
             ) {
+                if (DEBUG_SERVO) ClockworkMod.LOGGER.info("[PhysBearing] tryMakeJoint: ships not loaded yet; retrying next tick (ship0={}, ship1={}, jointId={})", joint.shipId0, joint.shipId1, jointID)
                 tryNextTick()
                 return@physTickOnce
+            }
+            val existing = level.getJointById(jointID)
+            if (existing != null) {
+                // If the stored jointId is still valid, prefer updating in-place over creating a second joint.
+                if (existing is VSRevoluteJoint && joint is VSRevoluteJoint &&
+                    existing.shipId0 == joint.shipId0 && existing.shipId1 == joint.shipId1
+                ) {
+                    level.updateJoint(jointID, joint)
+                    isRunning = true
+                    return@physTickOnce
+                }
+                if (existing == joint) {
+                    isRunning = true
+                    return@physTickOnce
+                }
             }
             val id = level.addJoint(joint)
             if (id == -1) {
@@ -564,8 +700,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         joint = VSRevoluteJoint(
             shiptraptionID, VSJointPose(bearingPos.fma(-extraDist, axis, Vector3d()), ship1rot),
             shipOnID, VSJointPose(posInOwnerShip.fma(-extraDist, axis, Vector3d()), ship2rot),
-            compliance = 1e-100,
-            driveFreeSpin = true//movementMode!!.get() != LockedMode.LOCKED,
+            maxForceTorque = VSJointMaxForceTorque(SERVO_MAX_FORCE, SERVO_MAX_TORQUE),
+            compliance = SERVO_COMPLIANCE,
+            driveFreeSpin = true
 //            driveVelocity = newDriveVelocity,
         )
 
@@ -576,7 +713,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             bearingAxis.get(Vector3d()),
             Math.toRadians(targetAngle.toDouble()),
             getRealisticAngularSpeed(),
-            movementMode!!.get() == LockedMode.FOLLOW_ANGLE,
+            (movementMode?.get() ?: LockedMode.UNLOCKED) != LockedMode.UNLOCKED,
             aligning,
             shipOnID ?: -1L,
             joint!!.pose1.pos.get(Vector3d()),
@@ -584,6 +721,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         )
 
         tryMakeJoint()
+        updateDrive()
 
         sendData()
         updateGeneratedRotation()
@@ -611,6 +749,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             disassembleWhenPossible = !disassembleWhenPossible
             aligning = !aligning
             BearingController.getOrCreate(ship)!!.bearingData[bearingID]?.let { it.aligning = this.aligning }
+            updateDrive()
         } else {
             shipDisassemble()
         }
@@ -649,6 +788,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             aligning = false
             assembleNextTick = false
             disassembleWhenPossible = false
+            updateDrive()
             return
         }
         BearingController.getOrCreate(subShip)!!.removePhysBearing(bearingID)
@@ -670,10 +810,11 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         sendData()
         jointID = -1
         aligning = false
+        servoMode = LockedMode.UNLOCKED
+        lockedHoldAngleRad = null
+        followOmegaFeedForwardRadSec = 0.0
+        lastAligningState = false
 
-        sDir1 = null
-        sDir2 = null
-        pTick = 0
         lastAngle = 0f
         curAngle = 0f
     }
@@ -687,23 +828,30 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
     private fun tryUpdateData() {
         if (shiptraptionID == NO_SHIPTRAPTION_ID) {return}
-        if (   (lastSpeed == getSpeed() && lastMode == movementMode?.get())
-            && (movementMode!!.get() != LockedMode.FOLLOW_ANGLE && !aligning)
-        ) {return}
+        val mode = movementMode?.get() ?: LockedMode.UNLOCKED
+        val speedNow = getSpeed()
+        val aligningNow = aligning
 
-        if (lastMode != movementMode?.get() && movementMode?.get() == LockedMode.FOLLOW_ANGLE) {
-            val shipOn = level!!.getShipObjectManagingPos(blockPos)?.transform
-            val shiptraption = level!!.shipObjectWorld.allShips.getById(shiptraptionID)?.transform ?: return
-
-            targetAngle = Math.toDegrees(getAngle(bearingAxis, shiptraption, shipOn)).toFloat()
+        if (lastSpeed == speedNow && lastMode == mode && lastAligningState == aligningNow) {
+            return
         }
 
-        lastSpeed = getSpeed()
-        lastMode = movementMode!!.get()
+        // When entering a hold mode, capture the current physical angle to avoid any instantaneous jump.
+        if (lastMode != mode && (mode == LockedMode.FOLLOW_ANGLE || mode == LockedMode.LOCKED)) {
+            val shipOn = level!!.getShipObjectManagingPos(blockPos)?.transform
+            val shiptraption = level!!.shipObjectWorld.allShips.getById(shiptraptionID)?.transform ?: return
+            val currentRad = getAngle(bearingAxis, shiptraption, shipOn)
+            targetAngle = Math.toDegrees(currentRad).toFloat()
+            lockedHoldAngleRad = if (mode == LockedMode.LOCKED) currentRad else null
+        } else if (lastMode == LockedMode.LOCKED && mode != LockedMode.LOCKED) {
+            lockedHoldAngleRad = null
+        }
 
-        val realSpeed = if (abs(getSpeed()) > 0.0f) getRealisticAngularSpeed() else 0.0f
-        val newDriveVelocity = if (realSpeed != 0.0f) VSRevoluteJoint.VSRevoluteDriveVelocity(getRealisticAngularSpeed(), true) else null
-        updateDrive(newDriveVelocity)
+        lastSpeed = speedNow
+        lastMode = mode
+        lastAligningState = aligningNow
+
+        updateDrive()
     }
 
     private fun tickAnimationLogic() {
@@ -777,9 +925,10 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
         tickAnimationLogic()
         if (!isRunning) return
+        val mode = movementMode?.get() ?: LockedMode.UNLOCKED
         if (shiptraptionID == NO_SHIPTRAPTION_ID) {
             targetAngle = 0f
-        } else if (joint != null && jointID != -1) {
+        } else if (joint != null && jointID != -1 && !aligning && mode != LockedMode.LOCKED) {
             val angularSpeed = -getActualAngularSpeed()
             var diff = 0.0f
 
@@ -826,9 +975,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         if (level != null && !level!!.isClientSide && joint != null) {
             lastSpeed = getSpeed()
-            val realSpeed = if (abs(getSpeed()) > 0.0f) getRealisticAngularSpeed() else 0.0f
-            val newDriveVelocity = if (realSpeed != 0.0f) VSRevoluteJoint.VSRevoluteDriveVelocity(getRealisticAngularSpeed(), true) else VSRevoluteJoint.VSRevoluteDriveVelocity(0f, true)
-            updateDrive(newDriveVelocity)
+            updateDrive()
         }
         super.onSpeedChanged(previousSpeed)
     }
@@ -868,6 +1015,26 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
     companion object {
         const val NO_SHIPTRAPTION_ID: Long = -1
+
+        // Servo tuning (acceleration-space PD):
+        //   alpha_cmd = Kp * angle_error + Kd * (omega_target - omega_actual)
+        // Then we apply torque = I_eff * alpha_cmd.
+        private const val SERVO_KP = 250.0 // (rad/s^2)/rad
+        private const val SERVO_KD = 40.0  // (rad/s^2)/(rad/s)
+        private const val SERVO_MAX_OMEGA = 80.0 // rad/s (feed-forward clamp)
+        private const val SERVO_MAX_ALPHA = 120.0 // rad/s^2 (hard stability clamp)
+        private const val SERVO_MAX_ERROR_RAD = 0.75 // rad (~43 deg), avoids absurd snap torques on large steps
+        private const val SERVO_DEADBAND_RAD = 1.0e-4 // ~0.006 degrees
+
+        // Joint strength. Values are intentionally very high to avoid "sagging".
+        private const val SERVO_MAX_FORCE = 1.0e9f
+        private const val SERVO_MAX_TORQUE = 1.0e9f
+        private const val SERVO_DRIVE_FORCE_LIMIT = 1.0e9f
+
+        // Extremely stiff, but not pathological (avoid ~1e-100 which can blow up solvers).
+        private const val SERVO_COMPLIANCE = 1.0e-10
+
+        private const val DEBUG_SERVO = false
 
         //tolerance is in degrees
         @JvmStatic

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -128,6 +128,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     private var lastSpeed = 0f
     private var lastMode = LockedMode.UNLOCKED
     private var lastAligningState = false
+    private var missingSubShipTicks = 0
 
     // Phys-thread reads these; game-thread writes them.
     @Volatile private var servoMode: LockedMode = LockedMode.UNLOCKED
@@ -997,6 +998,34 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
                 loadingFn = null
             }
 
+            // If the attached sub-ship was deleted (e.g., removed by VS), stop the bearing and let it close.
+            // Use allShips (not loadedShips) so chunk load ordering doesn't spuriously disable the bearing.
+            if (isRunning && shiptraptionID != NO_SHIPTRAPTION_ID) {
+                val sLevel = level as ServerLevel
+                val exists = sLevel.shipObjectWorld.allShips.getById(shiptraptionID) != null
+                if (!exists) {
+                    missingSubShipTicks++
+                    if (missingSubShipTicks >= MISSING_SUBSHIP_GRACE_TICKS) {
+                        if (DEBUG_SERVO) {
+                            ClockworkMod.LOGGER.info("[PhysBearing] subShip missing; disabling (shipId={}, jointId={})", shiptraptionID, jointID)
+                        }
+                        if (jointID != -1) sLevel.gtpa.removeJoint(jointID)
+                        controllerCreationData = null
+                        controllerUpdateData = null
+                        // Ensure the close animation can run even if we were mid-opening.
+                        if (!open && openProgress > 0f) open = true
+                        opening = false
+                        resetState()
+                        tickAnimationLogic()
+                        return
+                    }
+                } else {
+                    missingSubShipTicks = 0
+                }
+            } else {
+                missingSubShipTicks = 0
+            }
+
             val subShip = (level as ServerLevel).shipObjectWorld.loadedShips.getById(shiptraptionID)
             controllerCreationData?.also {
                 bearingID = BearingController
@@ -1209,7 +1238,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         // - "Stiffness" controls closed-loop natural frequency (wn), with Kp = wn^2.
         // - Kd is chosen for a fixed damping ratio to minimize sway/overshoot.
         // - "Strength" caps both max torque and max angular acceleration.
-        // Temporary: boost slider magnitudes for testing (e.g., UI 100 behaves like 1000).
+        // Temporary: boost slider magnitudes for testing (e.g., UI 100 behaves like 1000 if set to 10.0).
         private const val SERVO_TEST_SCALE = 1.0
         private const val SERVO_DAMPING_RATIO = 1.25
         private const val SERVO_WN_MIN = 4.0
@@ -1218,6 +1247,8 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_ALPHA_MAX = 480.0
         private const val SERVO_FORCE_TORQUE_MIN = 1.0e8
         private const val SERVO_FORCE_TORQUE_MAX = 1.0e10
+
+        private const val MISSING_SUBSHIP_GRACE_TICKS = 20
 
         // Servo tuning (acceleration-space PD):
         //   alpha_cmd = Kp * angle_error + Kd * (omega_target - omega_actual)

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/contraptions/phys/bearing/PhysBearingBlockEntity.kt
@@ -166,6 +166,11 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
     @Volatile private var servoApparentInertiaScale: Double = 1.0
     @Volatile private var servoPrevOmegaActualForApparentInertiaScaleRadSec: Double = Double.NaN
     @Volatile private var servoPrevAppliedHingeTorqueMag: Double = 0.0
+    @Volatile private var tickAuthority: Double = 1.0
+    @Volatile private var tickChainedDynamic: Boolean = false
+    @Volatile private var tickGyroRisk: Boolean = false
+    @Volatile private var omegaEmaRadSec: Double = 0.0
+    @Volatile private var appInertiaConsistentTicks: Int = 0
 
     private var controllerCreationData: PhysBearingData? = null
     private var controllerUpdateData: PhysBearingUpdateData? = null
@@ -453,6 +458,11 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         servoApparentInertiaScale = 1.0
         servoPrevOmegaActualForApparentInertiaScaleRadSec = Double.NaN
         servoPrevAppliedHingeTorqueMag = 0.0
+        omegaEmaRadSec = 0.0
+        appInertiaConsistentTicks = 0
+        tickAuthority = 1.0
+        tickChainedDynamic = false
+        tickGyroRisk = false
     }
 
     private fun servoStrength01(): Double {
@@ -485,7 +495,13 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         omegaErr: Double
     ): Double {
         val maxScale = apparentInertiaScaleMax()
-        var scale = servoApparentInertiaScale.coerceIn(1.0, maxScale)
+        val maxScaleLocal = if (tickChainedDynamic) {
+            // Harder cap in chains unless slider is very high via apparentInertiaScaleMax().
+            lerpClamped(2.0, maxScale, chainAuthorityBlend01())
+        } else {
+            maxScale
+        }
+        var scale = servoApparentInertiaScale.coerceIn(1.0, maxScaleLocal)
         val dt = SERVO_PHYS_TICK_DT_SEC
         val prevOmega = servoPrevOmegaActualForApparentInertiaScaleRadSec
         val prevTorque = servoPrevAppliedHingeTorqueMag
@@ -493,30 +509,53 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             abs(errorRad) > SERVO_APPARENT_INERTIA_ACTIVE_ERROR_RAD ||
                 abs(omegaErr) > SERVO_APPARENT_INERTIA_ACTIVE_OMEGA_ERR_RAD_SEC
 
-        if (
-            demandingMotion &&
-            dt > 1.0e-6 &&
-            baseInertia.isFinite() &&
-            baseInertia > SERVO_APPARENT_INERTIA_MIN_BASE &&
-            prevOmega.isFinite() &&
-            prevTorque.isFinite() &&
-            abs(prevTorque) > SERVO_APPARENT_INERTIA_MIN_OBS_TORQUE
-        ) {
-            val alphaObserved = (omegaActual - prevOmega) / dt
-            if (alphaObserved.isFinite()) {
-                if (prevTorque * alphaObserved > 0.0) {
-                    // Keep denominator bounded so near-zero measured accel under heavy load drives authority up quickly.
-                    val alphaDenom = max(abs(alphaObserved), SERVO_APPARENT_INERTIA_ALPHA_FLOOR_RAD_SEC2)
-                    val targetScale = (abs(prevTorque) / (baseInertia * alphaDenom)).coerceIn(1.0, maxScale)
-                    val lpAlpha =
-                        if (targetScale > scale) SERVO_APPARENT_INERTIA_RISE_ALPHA else SERVO_APPARENT_INERTIA_FALL_ALPHA
-                    scale = lowPass(scale, targetScale, lpAlpha)
+        if (demandingMotion) {
+            if (
+                dt > 1.0e-6 &&
+                baseInertia.isFinite() &&
+                baseInertia > SERVO_APPARENT_INERTIA_MIN_BASE &&
+                prevOmega.isFinite() &&
+                prevTorque.isFinite() &&
+                abs(prevTorque) > SERVO_APPARENT_INERTIA_MIN_OBS_TORQUE
+            ) {
+                val alphaObserved = (omegaActual - prevOmega) / dt
+                if (alphaObserved.isFinite()) {
+                    if (prevTorque * alphaObserved > 0.0) {
+                        appInertiaConsistentTicks++
+                    } else {
+                        appInertiaConsistentTicks = 0
+                    }
+
+                    // Debounce: require consistent sign for a few ticks before increasing scale.
+                    if (appInertiaConsistentTicks < APP_INERTIA_DEBOUNCE_TICKS) {
+                        scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_OPPOSED_DECAY_ALPHA)
+                    } else {
+                        val alphaDenom = max(abs(alphaObserved), SERVO_APPARENT_INERTIA_ALPHA_FLOOR_RAD_SEC2)
+                        val targetScale = (abs(prevTorque) / (baseInertia * alphaDenom)).coerceIn(1.0, maxScaleLocal)
+
+                        val lpAlpha =
+                            if (targetScale > scale) SERVO_APPARENT_INERTIA_RISE_ALPHA else SERVO_APPARENT_INERTIA_FALL_ALPHA
+                        val proposed = lowPass(scale, targetScale, lpAlpha)
+
+                        // Slew-rate limit to prevent explosive growth from noise.
+                        val maxRise = if (tickChainedDynamic) APP_INERTIA_MAX_RISE_PER_TICK_CHAIN else APP_INERTIA_MAX_RISE_PER_TICK
+                        val minFall = APP_INERTIA_MIN_FALL_PER_TICK
+                        val limited = proposed
+                            .coerceAtMost(scale * maxRise)
+                            .coerceAtLeast(scale * minFall)
+
+                        scale = limited
+                    }
                 } else {
-                    // Opposing acceleration usually means external disturbances/joint coupling; do not chase aggressively.
-                    scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_OPPOSED_DECAY_ALPHA)
+                    appInertiaConsistentTicks = 0
+                    scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA)
                 }
+            } else {
+                appInertiaConsistentTicks = 0
+                scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA)
             }
         } else {
+            appInertiaConsistentTicks = 0
             scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA)
         }
 
@@ -527,7 +566,7 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             scale = lowPass(scale, 1.0, SERVO_APPARENT_INERTIA_SETTLED_DECAY_ALPHA)
         }
 
-        val clamped = scale.coerceIn(1.0, maxScale)
+        val clamped = if (scale.isFinite()) scale.coerceIn(1.0, maxScaleLocal) else 1.0
         servoApparentInertiaScale = clamped
         servoPrevOmegaActualForApparentInertiaScaleRadSec = omegaActual
         return clamped
@@ -738,6 +777,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val subDynamic = !subShip.isStatic
         val mainDynamic = mainShip != null && !mainShip.isStatic
         if (!subDynamic && !mainDynamic) return
+        val authority = tickAuthority
+        val chainedDynamic = tickChainedDynamic
+        val gyroRisk = tickGyroRisk
 
         val anchor0World = subShip.transform.shipToWorld.transformPosition(joint.pose0.pos, Vector3d())
         val anchor1World = if (mainShip != null) {
@@ -755,7 +797,6 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val errorLen = anchorErrorRaw.length()
         val relVelLen = relVel.length()
         val worldAnchored = mainShip == null || mainShip.isStatic
-        val chainedDynamic = mainShip != null && !mainShip.isStatic && !subShip.isStatic
         val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
         val seatErrorDeadband = if (chainedDynamic) {
             lerpClamped(SERVO_SEAT_CHAIN_ERROR_DEADBAND_M, SERVO_SEAT_ERROR_DEADBAND_M, chainBlend)
@@ -767,7 +808,14 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         } else {
             SERVO_SEAT_VEL_DEADBAND
         }
-        if (errorLen < seatErrorDeadband && relVelLen < seatVelDeadband) return
+        val deadbandScale = when {
+            gyroRisk -> 3.0
+            chainedDynamic -> 2.0
+            else -> 1.0
+        }
+        val seatErrorDeadbandScaled = seatErrorDeadband * deadbandScale
+        val seatVelDeadbandScaled = seatVelDeadband * deadbandScale
+        if (errorLen < seatErrorDeadbandScaled && relVelLen < seatVelDeadbandScaled) return
         val anchorError = if (errorLen > SERVO_SEAT_MAX_ERROR_M && errorLen > 1.0e-9) {
             anchorErrorRaw.mul(SERVO_SEAT_MAX_ERROR_M / errorLen, Vector3d())
         } else {
@@ -808,16 +856,25 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val seatKp = seatWn * seatWn * seatKpScale
         val seatKd = 2.0 * seatDamping * seatWn * seatKdScale
 
+        val velSuppression = 1.0 / (1.0 + relVelLen * 2.0)
+        val seatAuthority = (authority * velSuppression).coerceIn(AUTH_MIN, 1.0)
         var seatAccCmd = anchorError.mul(seatKp, Vector3d()).add(relVel.mul(seatKd, Vector3d()))
+        seatAccCmd.mul(seatAuthority)
         if (!seatAccCmd.isFiniteVec()) return
         val maxSeatAccel = when {
             worldAnchored -> SERVO_SEAT_MAX_ACCEL_WORLD_ANCHOR
             chainedDynamic -> lerpClamped(SERVO_SEAT_MAX_ACCEL_CHAIN, SERVO_SEAT_MAX_ACCEL_HARD, chainBlend)
             else -> SERVO_SEAT_MAX_ACCEL_HARD
         }
+        val accelScale = when {
+            gyroRisk -> 0.35
+            chainedDynamic -> 0.60
+            else -> 1.0
+        }
+        val maxSeatAccelScaled = maxSeatAccel * accelScale * seatAuthority
         val seatAccLen = seatAccCmd.length()
-        if (seatAccLen > maxSeatAccel && seatAccLen > 1.0e-9) {
-            seatAccCmd.mul(maxSeatAccel / seatAccLen)
+        if (seatAccLen > maxSeatAccelScaled && seatAccLen > 1.0e-9) {
+            seatAccCmd.mul(maxSeatAccelScaled / seatAccLen)
         }
 
         var seatForce = seatAccCmd.mul(effMass, Vector3d())
@@ -830,9 +887,15 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         } else {
             minSeatForce
         }
+        val forceScale = when {
+            gyroRisk -> 0.40
+            chainedDynamic -> 0.70
+            else -> 1.0
+        }
+        val maxSeatForceScaled = maxSeatForce * forceScale * seatAuthority
         val seatForceLen = seatForce.length()
-        if (seatForceLen > maxSeatForce && seatForceLen > 1.0e-9) {
-            seatForce.mul(maxSeatForce / seatForceLen)
+        if (seatForceLen > maxSeatForceScaled && seatForceLen > 1.0e-9) {
+            seatForce.mul(maxSeatForceScaled / seatForceLen)
         }
 
         if (subDynamic) {
@@ -853,6 +916,9 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val subDynamic = !subShip.isStatic
         val mainDynamic = mainShip != null && !mainShip.isStatic
         if (!subDynamic && !mainDynamic) return
+        val authority = tickAuthority
+        val chainedDynamic = tickChainedDynamic
+        val gyroRisk = tickGyroRisk
 
         val swingErrorWorldRaw = computeSwingErrorWorld(subShip, mainShip, axisWorldUnit)
         val swingErrorLen = swingErrorWorldRaw.length()
@@ -864,14 +930,19 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         val offAxisOmega = rejectAlongAxis(relOmegaWorld, axisWorldUnit)
         val offAxisOmegaLen = offAxisOmega.length()
         val worldAnchored = mainShip == null || mainShip.isStatic
-        val chainedDynamic = mainShip != null && !mainShip.isStatic && !subShip.isStatic
         val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
         val tiltOmegaDeadband = if (chainedDynamic) {
             lerpClamped(SERVO_TILT_CHAIN_OMEGA_DEADBAND, SERVO_TILT_OMEGA_DEADBAND, chainBlend)
         } else {
             SERVO_TILT_OMEGA_DEADBAND
         }
-        if ((!offAxisOmegaLen.isFinite() || offAxisOmegaLen < tiltOmegaDeadband) && swingErrorWorld.length() < 1.0e-6) return
+        val tiltDeadbandScale = when {
+            gyroRisk -> 6.0
+            chainedDynamic -> 3.0
+            else -> 1.0
+        }
+        val tiltOmegaDeadbandScaled = tiltOmegaDeadband * tiltDeadbandScale
+        if ((!offAxisOmegaLen.isFinite() || offAxisOmegaLen < tiltOmegaDeadbandScaled) && swingErrorWorld.length() < 1.0e-6) return
 
         val sliderScale = SERVO_SLIDER_TEST_SCALE.coerceAtLeast(0.0)
         val tiltWnScale = when {
@@ -899,10 +970,13 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         } else {
             SERVO_TILT_FULL_STIFFNESS_ERROR_RAD
         }
+        val stiffnessAllowed = !gyroRisk && offAxisOmegaLen < 0.6 && abs(relOmegaWorld.dot(axisWorldUnit)).let { abs(it) } < 8.0
         val stiffnessBlend =
-            smoothStep(dampOnlyErrorRad, fullStiffnessErrorRad, swingErrorWorld.length())
+            if (stiffnessAllowed) smoothStep(dampOnlyErrorRad, fullStiffnessErrorRad, swingErrorWorld.length())
+            else 0.0
 
         var tiltAlphaCmd = swingErrorWorld.mul(-tiltKp * stiffnessBlend, Vector3d()).add(offAxisOmega.mul(-tiltKd, Vector3d()))
+        tiltAlphaCmd.mul(authority)
         if (!tiltAlphaCmd.isFiniteVec()) return
         var tiltAlphaLen = tiltAlphaCmd.length()
         val maxTiltAlpha = when {
@@ -954,10 +1028,16 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             else -> SERVO_TILT_MAX_ALPHA_EQUIV
         }
         val clampedMaxTiltTorque = min(maxTiltTorque, maxTiltTorqueByAlpha)
-        if (!clampedMaxTiltTorque.isFinite() || clampedMaxTiltTorque <= 0.0) return
+        val torqueScale = when {
+            gyroRisk -> 0.25
+            chainedDynamic -> 0.55
+            else -> 1.0
+        }
+        val clampedMaxTiltTorqueFinal = clampedMaxTiltTorque * torqueScale * authority
+        if (!clampedMaxTiltTorqueFinal.isFinite() || clampedMaxTiltTorqueFinal <= 0.0) return
         val tiltTorqueLen = tiltTorque.length()
-        if (tiltTorqueLen > clampedMaxTiltTorque && tiltTorqueLen > 1.0e-9) {
-            tiltTorque.mul(clampedMaxTiltTorque / tiltTorqueLen)
+        if (tiltTorqueLen > clampedMaxTiltTorqueFinal && tiltTorqueLen > 1.0e-9) {
+            tiltTorque.mul(clampedMaxTiltTorqueFinal / tiltTorqueLen)
         }
 
         if (subDynamic) {
@@ -1007,24 +1087,74 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         if (mainShip != null) relOmegaWorld.sub(mainShip.angularVelocity)
         val omegaActualRaw = relOmegaWorld.dot(axisWorld) // rad/s along the bearing axis
         if (!omegaActualRaw.isFinite()) return
+
+        // Update omega EMA for stability (reduces solver noise driving estimator/servo).
+        omegaEmaRadSec = lowPass(omegaEmaRadSec, omegaActualRaw, OMEGA_EMA_ALPHA)
+        val omegaActualForControl = if (omegaEmaRadSec.isFinite()) omegaEmaRadSec else omegaActualRaw
+
+        val offAxisOmegaWorld = rejectAlongAxis(relOmegaWorld, axisWorld)
+        val offAxisOmegaLen = offAxisOmegaWorld.length().let { if (it.isFinite()) it else 0.0 }
+
+        // Estimate anchor relative speed cheaply using existing helper (only if mainShip exists):
+        val anchor0World = subShip.transform.shipToWorld.transformPosition(revolute.pose0.pos, Vector3d())
+        val pose1Local = Vector3d(worldPosition.center.toJOML()).fma(-SERVO_JOINT_ANCHOR_OFFSET, bearingAxis, Vector3d())
+        val anchor1World =
+            if (mainShip != null) mainShip.transform.shipToWorld.transformPosition(pose1Local, Vector3d()) else pose1Local
+
+        val subAnchorVel = if (anchor0World.isFiniteVec()) getPointVelocityWorld(subShip, anchor0World) else Vector3d()
+        val mainAnchorVel = if (mainShip != null && anchor1World.isFiniteVec()) getPointVelocityWorld(mainShip, anchor1World) else Vector3d()
+        val relAnchorVel = mainAnchorVel.sub(subAnchorVel, Vector3d())
+        val relAnchorSpeed = relAnchorVel.length().let { if (it.isFinite()) it else 0.0 }
+
+        val chainedDynamic = !subShip.isStatic && mainShip != null && !mainShip.isStatic
+        tickChainedDynamic = chainedDynamic
+
+        val chainFactor = if (chainedDynamic) AUTH_CHAIN_BASE else 1.0
+        val omegaFactor = 1.0 / (1.0 + abs(omegaActualForControl) / AUTH_OMEGA_SOFT_LIMIT)
+        val offAxisFactor = 1.0 / (1.0 + offAxisOmegaLen / AUTH_OFFAXIS_SOFT_LIMIT)
+        val relVelFactor = 1.0 / (1.0 + relAnchorSpeed / AUTH_RELVEL_SOFT_LIMIT)
+        var authority = (chainFactor * omegaFactor * offAxisFactor * relVelFactor).coerceIn(AUTH_MIN, 1.0)
+
+        val gyroRisk =
+            (offAxisOmegaLen > GYRO_RISK_OFFAXIS_OMEGA) ||
+                (abs(omegaActualForControl) > GYRO_RISK_HINGE_OMEGA) ||
+                (relAnchorSpeed > GYRO_RISK_RELVEL)
+
+        tickGyroRisk = gyroRisk
+        if (gyroRisk) {
+            authority = max(AUTH_MIN, authority * 0.6)
+        }
+
         val errorForControl = errorRad.coerceIn(-SERVO_MAX_ERROR_RAD, SERVO_MAX_ERROR_RAD)
         val holdBlend = smoothStep(SERVO_HOLD_BLEND_ERROR_RAD, SERVO_HOLD_RELEASE_ERROR_RAD, abs(errorForControl))
 
         val omegaFilterAlpha = lerpClamped(SERVO_OMEGA_FILTER_ALPHA_NEAR_HOLD, SERVO_OMEGA_FILTER_ALPHA_ACTIVE, holdBlend)
-        servoOmegaActualFilteredRadSec = lowPass(servoOmegaActualFilteredRadSec, omegaActualRaw, omegaFilterAlpha)
+        servoOmegaActualFilteredRadSec = lowPass(servoOmegaActualFilteredRadSec, omegaActualForControl, omegaFilterAlpha)
         val omegaActual = if (servoOmegaActualFilteredRadSec.isFinite()) {
             servoOmegaActualFilteredRadSec
         } else {
-            omegaActualRaw
+            omegaActualForControl
         }
 
         // FOLLOW_ANGLE should respond immediately to kinetic input; use a feed-forward target omega and a PD in
         // acceleration-space. This avoids the "infinite torque" behavior that destabilizes heavy/offset ships.
-        val omegaFfRaw = if (!aligning && mode == LockedMode.FOLLOW_ANGLE && !followAngleStalled) {
+        var omegaFfRaw = if (!aligning && mode == LockedMode.FOLLOW_ANGLE && !followAngleStalled) {
             followOmegaFeedForwardRadSec.coerceIn(-SERVO_MAX_OMEGA, SERVO_MAX_OMEGA)
         } else {
             0.0
         }
+
+        // Prevent FF stacking in chains: strongly attenuate if both ships are dynamic.
+        if (chainedDynamic && omegaFfRaw != 0.0) {
+            // chainBlend is computed later currently; compute it here:
+            val chainBlendLocal = chainAuthorityBlend01()
+            val chainFfScale = lerpClamped(0.15, 0.65, chainBlendLocal)
+            omegaFfRaw *= chainFfScale
+        }
+
+        // Always apply authority to FF (stronger than linear to suppress oscillations).
+        omegaFfRaw *= (authority * authority)
+
         val followFfScale = if (!aligning && mode == LockedMode.FOLLOW_ANGLE && !followAngleStalled) {
             smoothStep(FOLLOW_FF_FADE_START_ERROR_RAD, FOLLOW_FF_FADE_END_ERROR_RAD, abs(errorForControl))
         } else {
@@ -1039,11 +1169,14 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
 
         // Close to hold, fade positional stiffness and let damping dominate.
-        val omegaFromPositionRaw = (servoPosGain * errorForControl).coerceIn(-servoPosOmegaLimit, servoPosOmegaLimit)
+        val posGainNow = servoPosGain * authority
+        val omegaGainNow = servoOmegaGain * authority
+
+        val omegaFromPositionRaw = (posGainNow * errorForControl).coerceIn(-servoPosOmegaLimit, servoPosOmegaLimit)
         val omegaFromPosition = omegaFromPositionRaw * holdBlend
         val omegaTarget = (omegaFromPosition + omegaFf).coerceIn(-SERVO_MAX_OMEGA, SERVO_MAX_OMEGA)
         val omegaErr = omegaTarget - omegaActual
-        var alphaCmdRaw = servoOmegaGain * omegaErr
+        var alphaCmdRaw = omegaGainNow * omegaErr
 
         // Prevent tiny setpoint chatter from exciting heavy ships near lock.
         if (
@@ -1062,6 +1195,12 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         } else {
             alphaCmdRaw
         }
+        val jitter = abs(alphaCmdRaw - alphaCmd).let { if (it.isFinite()) it else 0.0 }
+        if (jitter > AUTH_JITTER_SOFT_LIMIT) {
+            val jitterFactor = 1.0 / (1.0 + (jitter - AUTH_JITTER_SOFT_LIMIT) / AUTH_JITTER_SOFT_LIMIT)
+            authority = max(AUTH_MIN, authority * jitterFactor)
+        }
+        tickAuthority = authority
 
         // Discrete-time stability clamp: limit per-tick omega step to avoid high-frequency solver excitation.
         val maxOmegaStepPerTick = lerpClamped(
@@ -1095,7 +1234,6 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         }
 
         // Torque servo (works even when revolute drive velocity is not honored).
-        val chainedDynamic = !subShip.isStatic && mainShip != null && !mainShip.isStatic
         val chainBlend = if (chainedDynamic) chainAuthorityBlend01() else 1.0
         val torqueMassMultiplierBase: Double = run {
             val canSub = !subShip.isStatic
@@ -1119,13 +1257,14 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
             }
         }
         if (!torqueMassMultiplierBase.isFinite() || torqueMassMultiplierBase <= 0.0) {
+            appInertiaConsistentTicks = 0
             servoApparentInertiaScale = lowPass(servoApparentInertiaScale, 1.0, SERVO_APPARENT_INERTIA_IDLE_DECAY_ALPHA)
-            servoPrevOmegaActualForApparentInertiaScaleRadSec = omegaActual
+            servoPrevOmegaActualForApparentInertiaScaleRadSec = omegaActualForControl
             servoPrevAppliedHingeTorqueMag = 0.0
             return
         }
         val apparentInertiaScale =
-            updateApparentInertiaScale(torqueMassMultiplierBase, omegaActual, errorForControl, omegaErr)
+            updateApparentInertiaScale(torqueMassMultiplierBase, omegaActualForControl, errorForControl, omegaErr)
         val torqueMassMultiplier = torqueMassMultiplierBase * apparentInertiaScale
         if (!torqueMassMultiplier.isFinite() || torqueMassMultiplier <= 0.0) {
             servoPrevAppliedHingeTorqueMag = 0.0
@@ -1139,8 +1278,12 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         // Torque servo: tau = I_eff * alpha_cmd.
         var servoTorqueMag = torqueMassMultiplier * alphaCmd
         if (!servoTorqueMag.isFinite()) return
-        val maxTorque = if (servoTorqueLimit.isFinite() && servoTorqueLimit > 0.0) servoTorqueLimit else SERVO_TORQUE_MIN
-        servoTorqueMag = servoTorqueMag.coerceIn(-maxTorque, maxTorque)
+        val baseMaxTorque = if (servoTorqueLimit.isFinite() && servoTorqueLimit > 0.0) servoTorqueLimit else SERVO_TORQUE_MIN
+        var maxTorqueNow = baseMaxTorque * authority
+        if (gyroRisk) maxTorqueNow *= GYRO_RISK_TORQUE_SCALE
+        maxTorqueNow = max(maxTorqueNow, SERVO_TORQUE_MIN)
+
+        servoTorqueMag = servoTorqueMag.coerceIn(-maxTorqueNow, maxTorqueNow)
 
         // Explicit hinge-axis damping torque for hold/near-target operation:
         // tau_damp = -c * omega, where c = I_eff * damping_rate.
@@ -1154,18 +1297,19 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
 
         var dampingTorqueMag = 0.0
         if (applyHingeDamping) {
-            val dampingRate =
+            var dampingRate =
                 if (mode == LockedMode.LOCKED || aligning) SERVO_HINGE_DAMPING_RATE_LOCKED else SERVO_HINGE_DAMPING_RATE_NEAR_TARGET
+            if (gyroRisk) dampingRate *= 1.2
             val dampingCoeff = torqueMassMultiplier * dampingRate
             dampingTorqueMag = -dampingCoeff * omegaActual
             val maxDampingTorque = min(
-                maxTorque * SERVO_HINGE_DAMPING_MAX_TORQUE_FRACTION,
+                maxTorqueNow * SERVO_HINGE_DAMPING_MAX_TORQUE_FRACTION,
                 torqueMassMultiplier * SERVO_HINGE_DAMPING_MAX_ALPHA_EQUIV
             )
             dampingTorqueMag = dampingTorqueMag.coerceIn(-maxDampingTorque, maxDampingTorque)
         }
 
-        val torqueMag = (servoTorqueMag + dampingTorqueMag).coerceIn(-maxTorque, maxTorque)
+        val torqueMag = (servoTorqueMag + dampingTorqueMag).coerceIn(-maxTorqueNow, maxTorqueNow)
         if (!torqueMag.isFinite()) {
             servoPrevAppliedHingeTorqueMag = 0.0
             return
@@ -2041,6 +2185,15 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_CHAIN_AUTHORITY_BLEND_END = 0.70
         private const val SERVO_CHAIN_COUPLED_EQ_MAX_RATIO = 8.0
 
+        // Authority scheduler (chain/gyro stability)
+        private const val AUTH_MIN = 0.18
+        private const val AUTH_CHAIN_BASE = 0.55
+        private const val AUTH_OMEGA_SOFT_LIMIT = 6.0 // rad/s
+        private const val AUTH_OFFAXIS_SOFT_LIMIT = 1.2 // rad/s
+        private const val AUTH_RELVEL_SOFT_LIMIT = 0.6 // m/s
+        private const val AUTH_JITTER_SOFT_LIMIT = 40.0 // rad/s^2 difference between raw and filtered alpha
+        private const val OMEGA_EMA_ALPHA = 0.35 // omega EMA smoothing
+
         // Apparent inertia compensation:
         // Estimate effective hinge inertia from previous applied torque vs observed omega response, then scale
         // authority up for downstream chained loads so nested ships behave closer to one rigid assembly.
@@ -2060,6 +2213,18 @@ class PhysBearingBlockEntity(type: BlockEntityType<*>?, pos: BlockPos?, state: B
         private const val SERVO_APPARENT_INERTIA_SETTLED_ERROR_RAD = 0.01
         private const val SERVO_APPARENT_INERTIA_SETTLED_OMEGA_RAD_SEC = 0.10
         private const val SERVO_APPARENT_INERTIA_SETTLED_DECAY_ALPHA = 0.12
+
+        // Apparent inertia estimator stability
+        private const val APP_INERTIA_DEBOUNCE_TICKS = 3
+        private const val APP_INERTIA_MAX_RISE_PER_TICK_CHAIN = 1.04
+        private const val APP_INERTIA_MAX_RISE_PER_TICK = 1.08
+        private const val APP_INERTIA_MIN_FALL_PER_TICK = 0.98
+
+        // Gyro safety detection thresholds (heuristics)
+        private const val GYRO_RISK_OFFAXIS_OMEGA = 1.2 // rad/s
+        private const val GYRO_RISK_HINGE_OMEGA = 14.0 // rad/s
+        private const val GYRO_RISK_RELVEL = 1.0 // m/s
+        private const val GYRO_RISK_TORQUE_SCALE = 0.5
 
         // Hinge-axis explicit damping: tau_damp = -c * omega (c = I_eff * damping_rate).
         // Applied in LOCKED/aligning or when close to target with near-zero command.

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/platform/api/ContraptionController.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/platform/api/ContraptionController.kt
@@ -11,7 +11,7 @@ interface ContraptionController : IControlContraption {
         FOLLOW_ANGLE(AllIcons.I_ROTATE_PLACE),
         UNLOCKED(AllIcons.I_ROTATE_PLACE_RETURNED),
         //TODO idk how to safely remove this
-        LOCKED(AllIcons.I_ROTATE_PLACE);
+        LOCKED(AllIcons.I_DISABLE);
 
 
         private val translationKey: String

--- a/common/src/main/resources/assets/vs_clockwork/lang/en_us.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/en_us.json
@@ -368,7 +368,6 @@
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "Unlocked",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "Locked",
   "vs_clockwork.phys_bearing.servo_strength": "Servo Strength",
-  "vs_clockwork.phys_bearing.servo_stiffness": "Servo Stiffness",
 
   "vs_clockwork.gravitron.tool.grab": "Grab",
   "vs_clockwork.gravitron.tool.assemble": "Assemble",

--- a/common/src/main/resources/assets/vs_clockwork/lang/en_us.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/en_us.json
@@ -367,6 +367,8 @@
   "vs_clockwork.phys_bearing.rotation_mode.follow_angle": "Follow angle",
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "Unlocked",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "Locked",
+  "vs_clockwork.phys_bearing.servo_strength": "Servo Strength",
+  "vs_clockwork.phys_bearing.servo_stiffness": "Servo Stiffness",
 
   "vs_clockwork.gravitron.tool.grab": "Grab",
   "vs_clockwork.gravitron.tool.assemble": "Assemble",

--- a/common/src/main/resources/assets/vs_clockwork/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/fr_fr.json
@@ -364,6 +364,8 @@
   "vs_clockwork.phys_bearing.rotation_mode.follow_angle": "Suivre l'angle",
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "Débloqué",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "Bloqué",
+  "vs_clockwork.phys_bearing.servo_strength": "Force du servo",
+  "vs_clockwork.phys_bearing.servo_stiffness": "Rigidité du servo",
 
   "vs_clockwork.gravitron.tool.grab": "Attraper",
   "vs_clockwork.gravitron.tool.assemble": "Assembler",

--- a/common/src/main/resources/assets/vs_clockwork/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/ko_kr.json
@@ -382,6 +382,8 @@
   "vs_clockwork.phys_bearing.rotation_mode.follow_angle": "각도 따라가기",
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "잠금 해제됨",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "잠금됨",
+  "vs_clockwork.phys_bearing.servo_strength": "서보 강도",
+  "vs_clockwork.phys_bearing.servo_stiffness": "서보 강성",
 
   "vs_clockwork.gravitron.tool.grab": "잡기",
   "vs_clockwork.gravitron.tool.assemble": "조립",

--- a/common/src/main/resources/assets/vs_clockwork/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/ru_ru.json
@@ -399,6 +399,8 @@
   "vs_clockwork.phys_bearing.rotation_mode.follow_angle": "Соответствуя углу",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "Заблокированный",
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "Разблокированный",
+  "vs_clockwork.phys_bearing.servo_strength": "Сила сервопривода",
+  "vs_clockwork.phys_bearing.servo_stiffness": "Жёсткость сервопривода",
   "vs_clockwork.pump_duct.function1": "Создаёт разницу в давлении между",
   "vs_clockwork.pump_duct.function2": "помпой и газовой системой.",
   "vs_clockwork.subtitle.gravitron_fling": "Гравитрон запускает корабль",

--- a/common/src/main/resources/assets/vs_clockwork/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/tr_tr.json
@@ -364,6 +364,8 @@
   "vs_clockwork.phys_bearing.rotation_mode.follow_angle": "Açıyı Takip Et",
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "Açık",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "Kilitli",
+  "vs_clockwork.phys_bearing.servo_strength": "Servo Gücü",
+  "vs_clockwork.phys_bearing.servo_stiffness": "Servo Sertliği",
 
   "vs_clockwork.gravitron.tool.grab": "Tut",
   "vs_clockwork.gravitron.tool.assemble": "Monte Et",

--- a/common/src/main/resources/assets/vs_clockwork/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vs_clockwork/lang/zh_cn.json
@@ -367,6 +367,8 @@
   "vs_clockwork.phys_bearing.rotation_mode.follow_angle": "跟随角度",
   "vs_clockwork.phys_bearing.rotation_mode.unlocked": "未锁定",
   "vs_clockwork.phys_bearing.rotation_mode.locked": "锁定",
+  "vs_clockwork.phys_bearing.servo_strength": "伺服强度",
+  "vs_clockwork.phys_bearing.servo_stiffness": "伺服刚度",
 
   "vs_clockwork.gravitron.tool.grab": "抓取",
   "vs_clockwork.gravitron.tool.assemble": "组装",


### PR DESCRIPTION
This PR overhauls the core implementation of Phys Bearings, making them fully physics-driven, stable, and configurable.

# Changes:

- Configurable behavior: Bearing strength and stiffness can now be tuned, allowing players to experiment with different setups and build more advanced mechanical systems.
- True physics integration: Phys bearings now use revolute joints, properly respecting collisions and interacting naturally with the world and other entities.
- Improved stability: Ships using phys bearings no longer launch into the air when loading; they remain exactly where they were left.

# Result:
Phys bearings are now predictable, physically accurate, and flexible enough to support complex, creative mechanisms without the instability issues present before.