### PR TITLE
Fixed Wanderwand Deselect.

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/curiosities/tools/wanderwand/WanderwandItem.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/curiosities/tools/wanderwand/WanderwandItem.kt
@@ -105,7 +105,8 @@ class WanderwandItem(properties: Properties) : CWItem(properties) {
                         val existingSelectionDeser = readAABBSetFromNBT(existingSelection)
                         val out = existingSelectionDeser.subtractWithAABB(selection)
                         wand.tag?.remove("selectedBlocks")
-                        wand.tag?.put("selectedBlocks", writeAABBSetToNBT(out))
+                        val optimizedOut = mergeAdjacentFast(out)
+                        wand.tag?.put("selectedBlocks", writeAABBSetToNBT(optimizedOut))
                     }
                 }
                 sendTo(WanderwandRenderUpdatePacket(firstPos, if (deselect) ToolType.DESELECT else ToolType.SELECT, blocks = wand.tag?.get("selectedBlocks") as? CompoundTag?), sPlayer)

--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/util/AABBHelper.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/util/AABBHelper.kt
@@ -6,7 +6,7 @@ import org.joml.primitives.AABBic
 object AABBHelper {
 
     private fun isEmpty(b: AABBi): Boolean =
-        b.minX == b.maxX || b.minY == b.maxY || b.minZ == b.maxZ
+        b.minX >= b.maxX || b.minY >= b.maxY || b.minZ >= b.maxZ
 
     private fun intersectionHalfOpen(a: AABBi, c: AABBi): AABBi? {
         val ix0 = maxOf(a.minX, c.minX)


### PR DESCRIPTION
A logic flaw in AABBHelper.kt caused deselection which didn't prefectly alight with selections to expand the selected area unintendedly. Also repeated deselections would lead to fragementing bounding boxes, causing NBT Data to grow rapidly. Both of these issues are now fixed.