### PR TITLE
Update BalloonController.kt to fix balloon formation bug

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/clockwork/content/forces/BalloonController.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/clockwork/content/forces/BalloonController.kt
@@ -202,7 +202,9 @@ class BalloonController: ShipPhysicsListener {
 
         val shell = scanShell(shellStart, level, ClockworkConfig.SERVER.hotAirBalloonMaxScanSurface.toInt())
             ?: return -1
-        val seed = findInteriorSeedFromTop(shell.topShellPos, level) ?: return -1
+
+        //Finding valid position inside the balloon
+        val seed = shellStart.relative(Direction.DOWN)//findInteriorSeedFromTop(shell.topShellPos, level) ?: return -1
         val filled = tryFillBalloonFromShell(shell, seed, level)
         if (filled.isEmpty()) {
             return -1


### PR DESCRIPTION
Changes tryGetOrCreateBalloon() to start balloon fill from block below where it started shell fill rather than point below highest block in shell; shell can at times extend far beyond the bounds of the balloon proper and so space below highest block in shell may be outside of balloon.